### PR TITLE
When Transfer-Length is not present in FDT, use value of Content-Length

### DIFF
--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -79,6 +79,8 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
     val = file->Attribute("Transfer-Length");
     if (val != nullptr) {
       transfer_length = strtoull(val, nullptr, 0);
+    } else {
+      transfer_length = content_length;
     }
 
     auto content_md5 = file->Attribute("Content-MD5");


### PR DESCRIPTION
For Compact-NoCode transfer encoding, the R&S core no longer encodes the Transfer-Length attribute in the FDT (as it's identical to the Content-Length anyway). We can use the value of Content-Length instead.