### PR TITLE
Fixes for compiler warnings found during MBS User Services development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(PkgConfig REQUIRED)
 find_package(OpenSSL REQUIRED)
 pkg_check_modules(TINYXML REQUIRED IMPORTED_TARGET tinyxml2)
 pkg_check_modules(NETLINK REQUIRED IMPORTED_TARGET libnl-3.0)
+pkg_check_modules(LIBCONFIG REQUIRED IMPORTED_TARGET libconfig++)
 
 add_subdirectory(examples)
 

--- a/include/EncodingSymbol.h
+++ b/include/EncodingSymbol.h
@@ -47,9 +47,10 @@ namespace LibFlute {
       EncodingSymbol(uint32_t id, uint32_t source_block_number, char* encoded_data, size_t data_len, FecScheme fec_scheme)
         : _id(id)
         , _source_block_number(source_block_number)
+        , _fec_scheme(fec_scheme)
         , _encoded_data(encoded_data)
         , _data_len(data_len)
-        , _fec_scheme(fec_scheme) {}
+      {};
 
      /**
       *  Default destructor.

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -107,8 +107,8 @@ namespace LibFlute {
       void file_transmitted(uint32_t toi);
 
       void handle_send_to(const boost::system::error_code& error);
-      boost::asio::ip::udp::socket _socket;
       boost::asio::ip::udp::endpoint _endpoint;
+      boost::asio::ip::udp::socket _socket;
       boost::asio::io_service& _io_service;
       boost::asio::deadline_timer _send_timer;
       boost::asio::deadline_timer _fdt_timer;

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
+// Suppress warnings about MD5 being deprecated in later versions of OpenSSL
+#define OPENSSL_SUPPRESS_DEPRECATED 1
 #include <openssl/md5.h>
 #include "base64.h"
 #include "spdlog/spdlog.h"
@@ -168,13 +170,13 @@ auto LibFlute::File::create_blocks() -> void
   // Create the required source blocks and encoding symbols
   auto buffer_ptr = _buffer;
   size_t remaining_size = _meta.fec_oti.transfer_length;
-  auto number = 0;
+  decltype(_nof_large_source_blocks) number = 0;
   while (remaining_size > 0) {
     SourceBlock block;
-    auto symbol_id = 0;
+    size_t symbol_id = 0;
     auto block_length = ( number < _nof_large_source_blocks ) ? _large_source_block_length : _small_source_block_length;
 
-    for (int i = 0; i < block_length; i++) {
+    for (decltype(block_length) i = 0; i < block_length; i++) {
       auto symbol_length = std::min(remaining_size, (size_t)_meta.fec_oti.encoding_symbol_length);
       assert(buffer_ptr + symbol_length <= _buffer + _meta.fec_oti.transfer_length);
 
@@ -192,7 +194,6 @@ auto LibFlute::File::create_blocks() -> void
 
 auto LibFlute::File::get_next_symbols(size_t max_size) -> std::vector<EncodingSymbol> 
 {
-  auto block = _source_blocks.begin();
   int nof_symbols = std::ceil((float)(max_size - 4) / (float)_meta.fec_oti.encoding_symbol_length);
   auto cnt = 0;
   std::vector<EncodingSymbol> symbols;

--- a/src/IpSec.cpp
+++ b/src/IpSec.cpp
@@ -94,10 +94,6 @@ namespace LibFlute::IpSec {
     xsinfo.family = AF_INET;
     xsinfo.mode = XFRM_MODE_TRANSPORT;
 
-    struct {
-      struct xfrm_algo xa;
-      char buf[512];
-    } algo = {};
 
     std::vector<char> binary_key;
     for (unsigned int i = 0; i < key.length(); i += 2) {
@@ -106,18 +102,23 @@ namespace LibFlute::IpSec {
     if (binary_key.size() > 512) {
       throw "Key is too long";
     }
-    strcpy(algo.xa.alg_name, "aes");
-    algo.xa.alg_key_len = binary_key.size() * 8;
-    memcpy(algo.buf, &binary_key[0], binary_key.size());
+    size_t algo_size = sizeof(struct xfrm_algo) + binary_key.size();
+    void *algo_mem = std::malloc(algo_size);
+    struct xfrm_algo *algo = new(algo_mem) struct xfrm_algo;
+
+    strcpy(algo->alg_name, "aes");
+    algo->alg_key_len = binary_key.size() * 8;
+    memcpy(algo->alg_key, &binary_key[0], binary_key.size());
 
     msg = nlmsg_alloc_simple(XFRM_MSG_NEWSA, 0);
     nlmsg_append(msg, &xsinfo, sizeof(xsinfo), NLMSG_ALIGNTO);
-    nla_put(msg, XFRMA_ALG_CRYPT, sizeof(algo), &algo);
+    nla_put(msg, XFRMA_ALG_CRYPT, algo_size, algo);
 
     sk = nl_socket_alloc();
     nl_connect(sk, NETLINK_XFRM);
     nl_send_auto(sk, msg);
     nlmsg_free(msg);
+    std::free(algo);
   }
 
   void enable_esp(uint32_t spi, const std::string& dest_address, Direction direction, const std::string& key)

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -129,7 +129,7 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
       } else {
         spdlog::trace("Discarding packet for unknown or already completed file with TOI {}", alc.toi());
       }
-    } catch (std::exception ex) {
+    } catch (const std::exception &ex) {
       spdlog::warn("Failed to decode ALC/FLUTE packet: {}", ex.what());
     }
 

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -26,13 +26,15 @@ LibFlute::Transmitter::Transmitter ( const std::string& address,
     boost::asio::io_service& io_service)
     : _endpoint(boost::asio::ip::address::from_string(address), port)
     , _socket(io_service, _endpoint.protocol())
-    , _fdt_timer(io_service)
-    , _send_timer(io_service)
     , _io_service(io_service)
+    , _send_timer(io_service)
+    , _fdt_timer(io_service)
     , _tsi(tsi)
     , _mtu(mtu)
-    , _rate_limit(rate_limit)
+    , _files()
+    , _files_mutex()
     , _mcast_address(address)
+    , _rate_limit(rate_limit)
 {
   _max_payload = mtu -
     20 - // IPv4 header

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -71,7 +71,9 @@ auto LibFlute::Transmitter::handle_send_to(const boost::system::error_code& erro
 auto LibFlute::Transmitter::seconds_since_epoch() -> uint64_t 
 {
   return std::chrono::duration_cast<std::chrono::seconds>(
-      std::chrono::system_clock::now().time_since_epoch()).count();
+      std::chrono::system_clock::now().time_since_epoch()).count() +
+      2'208'988'800; /* add the difference in seconds between the Unix epoch (1 January 1970, 00:00:00 UTC)
+                        and the NTP epoch (1 January 1900, 00:00:00 UTC) */
 }
 
 auto LibFlute::Transmitter::send_fdt() -> void {
@@ -86,8 +88,11 @@ auto LibFlute::Transmitter::send_fdt() -> void {
         (char*)fdt.c_str(),
         fdt.length(),
         true);
-  file->set_fdt_instance_id( _fdt->instance_id() );
-  _files.insert_or_assign(0, file);
+  if (file) {
+    file->set_fdt_instance_id( _fdt->instance_id() );
+    spdlog::debug("Sending FDT instance {}:\n{}", _fdt->instance_id(), _fdt->to_string());
+    _files.insert_or_assign(0, file);
+  }
 }
 
 auto LibFlute::Transmitter::send(
@@ -182,7 +187,7 @@ auto LibFlute::Transmitter::send_next_packet() -> void
       _io_service.post(boost::bind(&Transmitter::send_next_packet, this));
     } else {
       auto send_duration = ((bytes_queued * 8.0) / (double)_rate_limit/1000.0) * 1000.0 * 1000.0;
-      spdlog::debug("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us", 
+      spdlog::trace("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us", 
           bytes_queued, _rate_limit, send_duration);
       _send_timer.expires_from_now(boost::posix_time::microseconds(
             static_cast<int>(ceil(send_duration))));


### PR DESCRIPTION
This fixes several compiler warnings and errors encountered during development of the MBS User Services components.

This pull request fixes:
- Include dependency for libconfig++ in the CMake files.
- Fix compiler warnings about member variables being initialised out of order.
- Fix mis-matched types from some "auto" variables.
- Fix compiler error about fixed length fields following flexible array fields in a struct.
- Add Klaus's fix for epoch on expiration timestamps in the FDT.