### PR TITLE
Add XML Namespace support to the FDT handling

### DIFF
--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -1,6 +1,7 @@
 // libflute - FLUTE/ALC library
 //
 // Copyright (C) 2021 Klaus Kühnhammer (Österreichische Rundfunksender GmbH & Co KG)
+//               2025 British Broadcasting Corporation (David Waring <david.waring2@bbc.co.uk>)
 //
 // Licensed under the License terms and conditions for use, reproduction, and
 // distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -9,7 +10,7 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
@@ -173,10 +174,10 @@ auto main(int argc, char **argv) -> int {
     LibFlute::Transmitter transmitter(
         arguments.mcast_target,
         (short)arguments.mcast_port,
-        0,
+        16,
         arguments.mtu,
         arguments.rate_limit,
-        io);
+        io, std::nullopt, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
 
     // Configure IPSEC ESP, if enabled
     if (arguments.enable_ipsec) 

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -27,12 +27,24 @@ namespace LibFlute {
   class FileDeliveryTable {
     public:
      /**
+      * FDT namespace enumeration
+      */
+      enum FdtNamespace {
+          FDT_NS_NONE = 0,
+          FDT_NS_RFC3926,
+          FDT_NS_DRAFT_2005,
+          FDT_NS_RFC6726,
+          FDT_NS_3GPP_CONSOLIDATED_V2
+      };
+
+     /**
       *  Create an empty FDT
       *
       *  @param instance_id FDT instance ID to set
       *  @param fec_oti Global FEC OTI parameters
+      *  @param fdt_namespace The XML namespace to use for FDT
       */
-      FileDeliveryTable(uint32_t instance_id, FecOti fec_oti);
+      FileDeliveryTable(uint32_t instance_id, FecOti fec_oti, FdtNamespace fdt_namespace = FDT_NS_NONE);
 
      /**
       *  Parse an XML string and create a FDT class from it
@@ -98,5 +110,7 @@ namespace LibFlute {
       FecOti _global_fec_oti;
 
       uint64_t _expires;
+
+      FdtNamespace _fdt_namespace;
   };
 };

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -1,6 +1,7 @@
 // libflute - FLUTE/ALC library
 //
 // Copyright (C) 2021 Klaus Kühnhammer (Österreichische Rundfunksender GmbH & Co KG)
+//               2025 British Broadcasting Corporation (David Waring <david.waring2@bbc.co.uk>)
 //
 // Licensed under the License terms and conditions for use, reproduction, and
 // distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -9,13 +10,14 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
 #pragma once
 #include <stddef.h>
 #include <stdint.h>
+#include <map>
 #include <string>
 #include <vector>
 #include "flute_types.h"
@@ -33,7 +35,7 @@ namespace LibFlute {
           FDT_NS_NONE = 0,
           FDT_NS_RFC3926,
           FDT_NS_DRAFT_2005,
-          FDT_NS_RFC6726,
+//          FDT_NS_RFC6726, // FLUTE v2 - will need other things implementing to use this correctly
           FDT_NS_3GPP_CONSOLIDATED_V2
       };
 

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -17,7 +17,6 @@
 #pragma once
 #include <stddef.h>
 #include <stdint.h>
-#include <map>
 #include <string>
 #include <vector>
 #include "flute_types.h"

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -1,6 +1,7 @@
 // libflute - FLUTE/ALC library
 //
 // Copyright (C) 2021 Klaus Kühnhammer (Österreichische Rundfunksender GmbH & Co KG)
+//               2025 British Broadcasting Corporation (David Waring <david.waring2@bbc.co.uk>)
 //
 // Licensed under the License terms and conditions for use, reproduction, and
 // distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -9,7 +10,7 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
@@ -32,6 +33,11 @@ namespace LibFlute {
   class Transmitter {
     public:
      /**
+      * FDT namespace enumeration
+      */
+      using FdtNamespace = FileDeliveryTable::FdtNamespace;
+
+     /**
       *  Definition of a file transmission completion callback function that can be
       *  registered through ::register_completion_callback.
       *
@@ -49,12 +55,14 @@ namespace LibFlute {
       *  @param rate_limit Transmit rate limit (in kbps)
       *  @param io_service Boost io_service to run the socket operations in (must be provided by the caller)
       *  @param tunnel_endpoint Tunnelling endpoint address (default: no tunnelling)
+      *  @param fdt_namespace Which XML namespace to use for the FDT (default: none)
       */
       Transmitter( const std::string& address, 
           short port, uint64_t tsi, unsigned short mtu,
           uint32_t rate_limit,
           boost::asio::io_service& io_service,
-          const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint = std::nullopt);
+          const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint = std::nullopt,
+          FdtNamespace fdt_namespace = FileDeliveryTable::FDT_NS_NONE);
 
      /**
       *  Default destructor.

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -1,6 +1,7 @@
 // libflute - FLUTE/ALC library
 //
 // Copyright (C) 2021 Klaus Kühnhammer (Österreichische Rundfunksender GmbH & Co KG)
+//               2025 British Broadcasting Corporation (David Waring <david.waring2@bbc.co.uk>)
 //
 // Licensed under the License terms and conditions for use, reproduction, and
 // distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -9,16 +10,106 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
 #include "FileDeliveryTable.h"
-#include "tinyxml2.h" 
+#include "tinyxml2.h"
 #include <iostream>
 #include <string>
+#include <map>
 #include "spdlog/spdlog.h"
 
+namespace {
+  class XMLNamespaces {
+  public:
+    XMLNamespaces() :_default_ns() ,_prefix_to_ns_map() {};
+    XMLNamespaces(const XMLNamespaces &to_copy) :_default_ns(to_copy._default_ns) ,_prefix_to_ns_map(to_copy._prefix_to_ns_map) {};
+    XMLNamespaces(XMLNamespaces &&to_move) :_default_ns(std::move(to_move._default_ns)) ,_prefix_to_ns_map(std::move(to_move._prefix_to_ns_map)) {};
+    XMLNamespaces(const tinyxml2::XMLElement *element, const XMLNamespaces &parent_ns = XMLNamespaces());
+
+    const tinyxml2::XMLElement *findChildElement(const tinyxml2::XMLElement *element, const std::string &name, const std::string &ns = std::string()) const;
+    const tinyxml2::XMLElement *findSiblingElement(const tinyxml2::XMLElement *child_elem, const std::string &name, const std::string &ns = std::string()) const;
+    const tinyxml2::XMLAttribute *findAttribute(const tinyxml2::XMLElement *element, const std::string &name, const std::string &ns = std::string()) const;
+    bool matches(const std::string &prefixed_name, const std::string &name, const std::string &ns = std::string()) const;
+    const std::string &elementNamespace(const tinyxml2::XMLElement *element) const;
+
+  private:
+    std::string _default_ns;   // namespace given for "xmlns=..."
+    std::map<std::string, std::string> _prefix_to_ns_map; // namespaces given for "xmlns:prefix=..."
+  };
+
+  XMLNamespaces::XMLNamespaces(const tinyxml2::XMLElement *element, const XMLNamespaces &parent_ns)
+    :_default_ns(parent_ns._default_ns)
+    ,_prefix_to_ns_map(parent_ns._prefix_to_ns_map)
+  {
+    if (!element) return;
+    for (auto attr_ptr = element->FirstAttribute(); attr_ptr; attr_ptr = attr_ptr->Next()) {
+      std::string attr_name = attr_ptr->Name();
+      if (attr_name == "xmlns") {
+        _default_ns = std::string(attr_ptr->Value());
+      } else if (attr_name.substr(0,6) == "xmlns:") {
+        _prefix_to_ns_map.insert(std::make_pair(attr_name.substr(6), std::string(attr_ptr->Value())));
+      }
+    }
+  }
+
+  const tinyxml2::XMLElement *XMLNamespaces::findChildElement(const tinyxml2::XMLElement *element, const std::string &name, const std::string &ns) const
+  {
+    if (!element) return nullptr;
+    auto elem_ptr = element->FirstChildElement();
+    if (!elem_ptr) return nullptr;
+    XMLNamespaces child_ns(elem_ptr, *this);
+    if (child_ns.matches(elem_ptr->Name(), name, ns)) return elem_ptr;
+    return findSiblingElement(elem_ptr, name, ns);
+  }
+
+  const tinyxml2::XMLElement *XMLNamespaces::findSiblingElement(const tinyxml2::XMLElement *child_elem, const std::string &name, const std::string &ns) const
+  {
+    if (!child_elem) return nullptr;
+    for (auto elem_ptr = child_elem->NextSiblingElement(); elem_ptr; elem_ptr = elem_ptr->NextSiblingElement()) {
+      XMLNamespaces child_ns(elem_ptr, *this);
+      if (child_ns.matches(elem_ptr->Name(), name, ns)) return elem_ptr;
+    }
+    return nullptr;
+  }
+
+  const tinyxml2::XMLAttribute *XMLNamespaces::findAttribute(const tinyxml2::XMLElement *element, const std::string &name, const std::string &ns) const
+  {
+    const std::string &elem_ns = elementNamespace(element);
+    for (auto attr_ptr = element->FirstAttribute(); attr_ptr; attr_ptr = attr_ptr->Next()) {
+      XMLNamespaces attr_ns(*this);
+      attr_ns._default_ns = elem_ns;
+      if (attr_ns.matches(attr_ptr->Name(), name, ns)) return attr_ptr;
+    }
+    return nullptr;
+  }
+
+  bool XMLNamespaces::matches(const std::string &prefixed_name, const std::string &name, const std::string &ns) const
+  {
+    std::string match_ns(_default_ns);
+    std::string match_name(prefixed_name);
+    auto pos = match_name.find_first_of(':');
+    if (pos != std::string::npos) {
+      auto prefix = match_name.substr(0,pos);
+      match_name.erase(0,pos+1);
+      match_ns = _prefix_to_ns_map.at(prefix);
+    }
+    return name == match_name && ns == match_ns;
+  }
+
+  const std::string &XMLNamespaces::elementNamespace(const tinyxml2::XMLElement *element) const
+  {
+    std::string elem_name(element->Name());
+    auto pos = elem_name.find_first_of(':');
+    if (pos != std::string::npos) {
+      auto elem_prefix = elem_name.substr(0,pos);
+      return _prefix_to_ns_map.at(elem_prefix);
+    }
+    return _default_ns;
+  }
+}
 
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_oti, FdtNamespace fdt_namespace)
   : _instance_id( instance_id )
@@ -30,91 +121,115 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffer, size_t len) 
   : _instance_id( instance_id )
 {
+  static const std::string mbms2007_ns("urn:3GPP:metadata:2007:MBMS:FLUTE:FDT");
   tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
   doc.Parse(buffer, len);
-  auto fdt_instance = doc.FirstChildElement("FDT-Instance");
-  _expires = std::stoull(fdt_instance->Attribute("Expires"));
+  auto fdt_instance = doc.RootElement();
+  XMLNamespaces root_ns(fdt_instance);
+  auto fdt_ns = root_ns.elementNamespace(fdt_instance);
+  if (!root_ns.matches(fdt_instance->Name(), "FDT-Instance", fdt_ns)) {
+    throw "Root element is not FDT-Instance";
+  }
+
+  if (fdt_ns == "") {
+    _fdt_namespace = FDT_NS_NONE;
+  } else if (fdt_ns == "http://www.example.com/flute") {
+    _fdt_namespace = FDT_NS_RFC3926;
+  } else if (fdt_ns == "urn:IETF:metadata:2005:FLUTE:FDT") {
+    _fdt_namespace = FDT_NS_DRAFT_2005;
+//  } else if (fdt_ns == "urn:ietf:params:xml:ns:fdt") { // FLUTEv2 - needs more work
+//    _fdt_namespace = FDT_NS_RFC6726;
+  } else if (fdt_ns == "urn:3GPP:metadata:2022:FLUTE:FDT") {
+    _fdt_namespace = FDT_NS_3GPP_CONSOLIDATED_V2;
+  } else {
+    throw "FDT namespace not recognised";
+  }
+
+  _expires = std::stoull(root_ns.findAttribute(fdt_instance, "Expires", fdt_ns)->Value());
 
   spdlog::debug("Received new FDT with instance ID {}: {}", instance_id, buffer);
 
   uint8_t def_fec_encoding_id = 0;
-  auto val = fdt_instance->Attribute("FEC-OTI-FEC-Encoding-ID");
+  auto val = root_ns.findAttribute(fdt_instance, "FEC-OTI-FEC-Encoding-ID", fdt_ns);
   if (val != nullptr) {
-    def_fec_encoding_id = strtoul(val, nullptr, 0);
+    def_fec_encoding_id = strtoul(val->Value(), nullptr, 0);
   }
 
   uint32_t def_fec_max_source_block_length = 0;
-  val = fdt_instance->Attribute("FEC-OTI-Maximum-Source-Block-Length");
+  val = root_ns.findAttribute(fdt_instance, "FEC-OTI-Maximum-Source-Block-Length", fdt_ns);
   if (val != nullptr) {
-    def_fec_max_source_block_length = strtoul(val, nullptr, 0);
+    def_fec_max_source_block_length = strtoul(val->Value(), nullptr, 0);
   }
 
   uint32_t def_fec_encoding_symbol_length = 0;
-  val = fdt_instance->Attribute("FEC-OTI-Encoding-Symbol-Length");
+  val = root_ns.findAttribute(fdt_instance, "FEC-OTI-Encoding-Symbol-Length", fdt_ns);
   if (val != nullptr) {
-    def_fec_encoding_symbol_length = strtoul(val, nullptr, 0);
+    def_fec_encoding_symbol_length = strtoul(val->Value(), nullptr, 0);
   }
 
-  for (auto file = fdt_instance->FirstChildElement("File"); 
-      file != nullptr; file = file->NextSiblingElement("File")) {
+  for (auto file = root_ns.findChildElement(fdt_instance, "File", fdt_ns);
+      file != nullptr; file = root_ns.findSiblingElement(file, "File", fdt_ns)) {
+
+    XMLNamespaces file_ns(file, root_ns);
 
     // required attributes
-    auto toi_str = file->Attribute("TOI");
+    auto toi_str = file_ns.findAttribute(file, "TOI", fdt_ns);
     if (toi_str == nullptr) {
       throw "Missing TOI attribute on File element";
     }
-    uint32_t toi = strtoull(toi_str, nullptr, 0);
+    uint32_t toi = strtoull(toi_str->Value(), nullptr, 0);
 
-    auto content_location = file->Attribute("Content-Location");
+    auto content_location = file_ns.findAttribute(file, "Content-Location", fdt_ns);
     if (content_location == nullptr) {
       throw "Missing Content-Location attribute on File element";
     }
 
     uint32_t content_length = 0;
-    val = file->Attribute("Content-Length");
+    val = file_ns.findAttribute(file, "Content-Length", fdt_ns);
     if (val != nullptr) {
-      content_length = strtoull(val, nullptr, 0);
+      content_length = strtoull(val->Value(), nullptr, 0);
     }
 
     uint32_t transfer_length = 0;
-    val = file->Attribute("Transfer-Length");
+    val = file_ns.findAttribute(file, "Transfer-Length", fdt_ns);
     if (val != nullptr) {
-      transfer_length = strtoull(val, nullptr, 0);
+      transfer_length = strtoull(val->Value(), nullptr, 0);
     } else {
       transfer_length = content_length;
     }
 
-    auto content_md5 = file->Attribute("Content-MD5");
+    auto content_md5 = file_ns.findAttribute(file, "Content-MD5", fdt_ns)->Value();
     if (!content_md5) {
       content_md5 = "";
     }
 
-    auto content_type = file->Attribute("Content-Type");
+    auto content_type = file_ns.findAttribute(file, "Content-Type", fdt_ns)->Value();
     if (!content_type) {
       content_type = "";
     }
 
     auto encoding_id = def_fec_encoding_id;
-    val = file->Attribute("FEC-OTI-FEC-Encoding-ID");
+    val = file_ns.findAttribute(file, "FEC-OTI-FEC-Encoding-ID", fdt_ns);
     if (val != nullptr) {
-      encoding_id = strtoul(val, nullptr, 0);
+      encoding_id = strtoul(val->Value(), nullptr, 0);
     }
 
     auto max_source_block_length = def_fec_max_source_block_length;
-    val = file->Attribute("FEC-OTI-Maximum-Source-Block-Length");
+    val = file_ns.findAttribute(file, "FEC-OTI-Maximum-Source-Block-Length", fdt_ns);
     if (val != nullptr) {
-      max_source_block_length = strtoul(val, nullptr, 0);
+      max_source_block_length = strtoul(val->Value(), nullptr, 0);
     }
 
     auto encoding_symbol_length = def_fec_encoding_symbol_length;
-    val = file->Attribute("FEC-OTI-Encoding-Symbol-Length");
+    val = file_ns.findAttribute(file, "FEC-OTI-Encoding-Symbol-Length", fdt_ns);
     if (val != nullptr) {
-      encoding_symbol_length = strtoul(val, nullptr, 0);
+      encoding_symbol_length = strtoul(val->Value(), nullptr, 0);
     }
     uint32_t expires = 0;
-    auto cc = file->FirstChildElement("mbms2007:Cache-Control");
+    auto cc = file_ns.findChildElement(file, "Cache-Control", mbms2007_ns);
     if (cc) {
-      auto expires_elem = cc->FirstChildElement("mbms2007:Expires");
+      XMLNamespaces cc_ns(cc, file_ns);
+      auto expires_elem = cc_ns.findChildElement(cc, "Expires", mbms2007_ns);
       if (expires_elem) {
         expires = strtoul(expires_elem->GetText(), nullptr, 0);
       }
@@ -129,7 +244,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
 
     FileEntry fe{
       toi,
-        std::string(content_location),
+        std::string(content_location->Value()),
         content_length,
         std::string(content_md5),
         std::string(content_type),
@@ -169,9 +284,9 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
     case FDT_NS_DRAFT_2005:
       root->SetAttribute("xmlns", "urn:IETF:metadata:2005:FLUTE:FDT");
       break;
-    case FDT_NS_RFC6726:
-      root->SetAttribute("xmlns", "urn:ietf:params:xml:ns:fdt");
-      break;
+//    case FDT_NS_RFC6726:  // FLUTE v2 - Will need other things implementing to use this
+//      root->SetAttribute("xmlns", "urn:ietf:params:xml:ns:fdt");
+//      break;
     case FDT_NS_3GPP_CONSOLIDATED_V2:
       root->SetAttribute("xmlns", "urn:3GPP:metadata:2022:FLUTE:FDT");
       break;

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -20,9 +20,10 @@
 #include "spdlog/spdlog.h"
 
 
-LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_oti)
+LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_oti, FdtNamespace fdt_namespace)
   : _instance_id( instance_id )
   , _global_fec_oti( fec_oti )
+  , _fdt_namespace( fdt_namespace )
 {
 }
 
@@ -161,6 +162,22 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
   tinyxml2::XMLDocument doc;
   doc.InsertFirstChild( doc.NewDeclaration() );
   auto root = doc.NewElement("FDT-Instance");
+  switch (_fdt_namespace) {
+    case FDT_NS_RFC3926:
+      root->SetAttribute("xmlns", "http://www.example.com/flute");
+      break;
+    case FDT_NS_DRAFT_2005:
+      root->SetAttribute("xmlns", "urn:IETF:metadata:2005:FLUTE:FDT");
+      break;
+    case FDT_NS_RFC6726:
+      root->SetAttribute("xmlns", "urn:ietf:params:xml:ns:fdt");
+      break;
+    case FDT_NS_3GPP_CONSOLIDATED_V2:
+      root->SetAttribute("xmlns", "urn:3GPP:metadata:2022:FLUTE:FDT");
+      break;
+    default:
+      break;
+  }
   root->SetAttribute("Expires", std::to_string(_expires).c_str());
   root->SetAttribute("FEC-OTI-FEC-Encoding-ID", (unsigned)_global_fec_oti.encoding_id);
   root->SetAttribute("FEC-OTI-Maximum-Source-Block-Length", (unsigned)_global_fec_oti.max_source_block_length);

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -121,7 +121,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffer, size_t len) 
   : _instance_id( instance_id )
 {
-  static const std::string mbms2007_ns("urn:3GPP:metadata:2007:MBMS:FLUTE:FDT");
+  static const std::string mbms2007_ns("urn:3GPP:metadata:2007:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
   tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
   doc.Parse(buffer, len);
   auto fdt_instance = doc.RootElement();
@@ -133,13 +133,13 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
 
   if (fdt_ns == "") {
     _fdt_namespace = FDT_NS_NONE;
-  } else if (fdt_ns == "http://www.example.com/flute") {
+  } else if (fdt_ns == "http://www.example.com/flute") { // RFC 3926 Section 3.4.2
     _fdt_namespace = FDT_NS_RFC3926;
-  } else if (fdt_ns == "urn:IETF:metadata:2005:FLUTE:FDT") {
+  } else if (fdt_ns == "urn:IETF:metadata:2005:FLUTE:FDT") { // 3GPP TS 26.346 Clause 7.2.10.1
     _fdt_namespace = FDT_NS_DRAFT_2005;
-//  } else if (fdt_ns == "urn:ietf:params:xml:ns:fdt") { // FLUTEv2 - needs more work
+//  } else if (fdt_ns == "urn:ietf:params:xml:ns:fdt") { // RFC 6726 - FLUTEv2 - needs more work
 //    _fdt_namespace = FDT_NS_RFC6726;
-  } else if (fdt_ns == "urn:3GPP:metadata:2022:FLUTE:FDT") {
+  } else if (fdt_ns == "urn:3GPP:metadata:2022:FLUTE:FDT") { // 3GPP TS 26.346 Clause L.6.1
     _fdt_namespace = FDT_NS_3GPP_CONSOLIDATED_V2;
   } else {
     throw "FDT namespace not recognised";
@@ -279,15 +279,19 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
   auto root = doc.NewElement("FDT-Instance");
   switch (_fdt_namespace) {
     case FDT_NS_RFC3926:
+      // RFC 3926 Section 3.4.2
       root->SetAttribute("xmlns", "http://www.example.com/flute");
       break;
     case FDT_NS_DRAFT_2005:
+      // 3GPP TS 26.346 Clause 7.2.10.1
       root->SetAttribute("xmlns", "urn:IETF:metadata:2005:FLUTE:FDT");
       break;
 //    case FDT_NS_RFC6726:  // FLUTE v2 - Will need other things implementing to use this
+//      // RFC 6726
 //      root->SetAttribute("xmlns", "urn:ietf:params:xml:ns:fdt");
 //      break;
     case FDT_NS_3GPP_CONSOLIDATED_V2:
+      // 3GPP TS 26.346 Clause L.6.1
       root->SetAttribute("xmlns", "urn:3GPP:metadata:2022:FLUTE:FDT");
       break;
     default:
@@ -297,7 +301,7 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
   root->SetAttribute("FEC-OTI-FEC-Encoding-ID", (unsigned)_global_fec_oti.encoding_id);
   root->SetAttribute("FEC-OTI-Maximum-Source-Block-Length", (unsigned)_global_fec_oti.max_source_block_length);
   root->SetAttribute("FEC-OTI-Encoding-Symbol-Length", (unsigned)_global_fec_oti.encoding_symbol_length);
-  root->SetAttribute("xmlns:mbms2007", "urn:3GPP:metadata:2007:MBMS:FLUTE:FDT");
+  root->SetAttribute("xmlns:mbms2007", "urn:3GPP:metadata:2007:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
   doc.InsertEndChild(root);
 
   for (const auto& file : _file_entries) {

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -1,6 +1,7 @@
 // libflute - FLUTE/ALC library
 //
 // Copyright (C) 2021 Klaus Kühnhammer (Österreichische Rundfunksender GmbH & Co KG)
+//               2025 British Broadcasting Corporation (David Waring <david.waring2@bbc.co.uk>)
 //
 // Licensed under the License terms and conditions for use, reproduction, and
 // distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -9,7 +10,7 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
@@ -35,7 +36,8 @@ static uint16_t calculate_sum( uint16_t *buffer, size_t len );
 LibFlute::Transmitter::Transmitter ( const std::string& address, short port,
                                      uint64_t tsi, unsigned short mtu, uint32_t rate_limit,
                                      boost::asio::io_service& io_service,
-                                     const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint )
+                                     const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint,
+                                     LibFlute::Transmitter::FdtNamespace fdt_namespace )
     : _endpoint(boost::asio::ip::address::from_string(address), port)
     , _socket(io_service, _endpoint.protocol())
     , _io_service(io_service)
@@ -69,7 +71,7 @@ LibFlute::Transmitter::Transmitter ( const std::string& address, short port,
   _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
 
   _fec_oti = FecOti{FecScheme::CompactNoCode, 0, _max_payload, max_source_block_length};
-  _fdt = std::make_unique<FileDeliveryTable>(1, _fec_oti);
+  _fdt = std::make_unique<FileDeliveryTable>(1, _fec_oti, fdt_namespace);
 
   _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
   _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this));


### PR DESCRIPTION
This adds support for the XML namespace ("xmlns" attribute) to be specified for the FDT.

This provides an extra optional parameter when constructing the the `Transmitter` class to set the XML namespace of the output. If no option is provided then it will continue with the present default of no XML namespace.

This also adds namespace identification and consistency checking to the XML parsing of the FDT for FLUTEv1 reception. This allows valid XML usage with an explicit namespace prefix to be parsed, like:
```xml
<?xml version="1.0"?>
<fdt:FDT-Instance xmlns:fdt="http://www.example.com/flute" ... >
   ...
</fdt:FDT-Instance>
```
This will allow rt-libflute to interoperate more widely with FLUTEv1 implementations which do not present their FDT's with the same XML namespace prefixes as this library.

All changes should maintain backward compatibility and behaviour with existing rt-libflute applications.

The namespaces used in this PR come from RFC 3926 (FLUTEv1) and 3GPP TS 26.346 (MBMS: Protocols and codecs - Clauses 7.2.10.1, 7.2.10.2 and L.6.1)