### PR TITLE
Add API to handle extra metadata fields for Files and remember TOI for resend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,19 +2,23 @@ cmake_minimum_required(VERSION 3.16)
 
 project (libflute VERSION 0.11.0)
 
+include(CheckCXXSymbolExists)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_CXX_FLAGS_DEBUG_INIT "-Wall -Wextra -Werror -g3")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "-Wall -O3")
 
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(OpenSSL REQUIRED)
 pkg_check_modules(TINYXML REQUIRED IMPORTED_TARGET tinyxml2)
 pkg_check_modules(NETLINK REQUIRED IMPORTED_TARGET libnl-3.0)
 pkg_check_modules(LIBCONFIG REQUIRED IMPORTED_TARGET libconfig++)
+pkg_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
+check_cxx_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
 
 add_subdirectory(examples)
 
@@ -36,6 +40,10 @@ link_directories(
 set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 add_library(flute "")
+if (HAVE_MMAP)
+    target_compile_definitions(flute PRIVATE HAVE_MMAP=1)
+endif()
+
 target_sources(flute
   PRIVATE
   src/Receiver.cpp src/Transmitter.cpp src/AlcPacket.cpp src/File.cpp src/EncodingSymbol.cpp src/FileDeliveryTable.cpp src/IpSec.cpp
@@ -58,5 +66,6 @@ target_link_libraries( flute
     crypto
     PkgConfig::TINYXML
     PkgConfig::NETLINK
+    PkgConfig::ZLIB
 )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS_DEBUG_INIT "-Wall -Wextra -Werror -g3")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "-Wall -O3")
 
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(PkgConfig REQUIRED)
 

--- a/examples/flute-receiver.cpp
+++ b/examples/flute-receiver.cpp
@@ -52,6 +52,7 @@ static struct argp_option options[] = {  // NOLINT
      "Log verbosity: 0 = trace, 1 = debug, 2 = info, 3 = warn, 4 = error, 5 = "
      "critical, 6 = none. Default: 2.",
      0},
+    {"tsi", 'T', "ID", 0, "The TSI to use for the FLUTE session (default: 16)", 0},
     {nullptr, 0, nullptr, 0, nullptr, 0}};
 
 /**
@@ -65,6 +66,7 @@ struct ft_arguments {
   unsigned short mcast_port = 40085;
   unsigned log_level = 2;        /**< log level */
   char **files;
+  uint64_t tsi = 16;
 };
 
 /**
@@ -88,6 +90,9 @@ static auto parse_opt(int key, char *arg, struct argp_state *state) -> error_t {
       break;
     case 'l':
       arguments->log_level = static_cast<unsigned>(strtoul(arg, nullptr, 10));
+      break;
+    case 'T':
+      arguments->tsi = static_cast<uint64_t>(strtoul(arg, nullptr, 10));
       break;
     default:
       return ARGP_ERR_UNKNOWN;
@@ -145,7 +150,7 @@ auto main(int argc, char **argv) -> int {
         arguments.flute_interface,
         arguments.mcast_target,
         (short)arguments.mcast_port,
-        16,
+        arguments.tsi,
         io);
 
     // Configure IPSEC, if enabled

--- a/examples/flute-receiver.cpp
+++ b/examples/flute-receiver.cpp
@@ -161,8 +161,8 @@ auto main(int argc, char **argv) -> int {
 
     receiver.register_completion_callback(
         [](std::shared_ptr<LibFlute::File> file) { //NOLINT
-        spdlog::info("{} (TOI {}) has been received",
-            file->meta().content_location, file->meta().toi);
+        spdlog::info("{} (TOI {}{}{}) has been received",
+            file->meta().content_location, file->meta().toi, file->meta().etag.empty()?"":", ETag = ", file->meta().etag);
         FILE* fd = fopen(file->meta().content_location.c_str(), "wb");
         fwrite(file->buffer(), 1, file->length(), fd);
         fclose(fd);

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -14,15 +14,19 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
-#include <cstdio>
-#include <iostream>
 #include <argp.h>
 
+#include <cstdio>
 #include <cstdlib>
 
+#include <chrono>
+#include <iostream>
+#include <list>
+#include <vector>
 #include <fstream>
 #include <string>
 #include <filesystem>
+
 #include <libconfig.h++>
 #include <boost/asio.hpp>
 
@@ -38,6 +42,8 @@ using libconfig::Config;
 using libconfig::FileIOException;
 using libconfig::ParseException;
 
+using namespace std::literals::chrono_literals;
+
 static void print_version(FILE *stream, struct argp_state *state);
 void (*argp_program_version_hook)(FILE *, struct argp_state *) = print_version;
 const char *argp_program_bug_address = "Austrian Broadcasting Services <obeca@ors.at>";
@@ -51,8 +57,11 @@ static struct argp_option options[] = {  // NOLINT
     {"ipsec-key", 'k', "KEY", 0, "To enable IPSec/ESP encryption of packets, provide a hex-encoded AES key here", 0},
     {"log-level", 'l', "LEVEL", 0,
      "Log verbosity: 0 = trace, 1 = debug, 2 = info, 3 = warn, 4 = error, 5 = "
-     "critical, 6 = none. Default: 2.",
+     "critical, 6 = none (default: 2)",
      0},
+    {"gzip", 'g', nullptr, 0, "Use gzip to compress the contents, implies -n option", 0},
+    {"tsi", 'T', "ID", 0, "The TSI to use for the FLUTE session (default: 16)", 0},
+    {"new-api", 'n', nullptr, 0, "Use the new FileDescription API", 0},
     {nullptr, 0, nullptr, 0, nullptr, 0}};
 
 /**
@@ -61,10 +70,13 @@ static struct argp_option options[] = {  // NOLINT
 struct ft_arguments {
   const char *mcast_target = {};
   bool enable_ipsec = false;
+  bool use_gzip = false;
+  bool new_api = false;
   const char *aes_key = {};
   unsigned short mcast_port = 40085;
   unsigned short mtu = 1500;
   uint32_t rate_limit = 1000;
+  uint64_t tsi = 16;
   unsigned log_level = 2;        /**< log level */
   char **files;
 };
@@ -94,6 +106,16 @@ static auto parse_opt(int key, char *arg, struct argp_state *state) -> error_t {
     case 'l':
       arguments->log_level = static_cast<unsigned>(strtoul(arg, nullptr, 10));
       break;
+    case 'g':
+      arguments->use_gzip = true;
+      arguments->new_api = true;
+      break;
+    case 'T':
+      arguments->tsi = static_cast<uint64_t>(strtoul(arg, nullptr, 10));
+      break;
+    case 'n':
+      arguments->new_api = true;
+      break;
     case ARGP_KEY_NO_ARGS:
       argp_usage (state);
     case ARGP_KEY_ARG:
@@ -117,6 +139,130 @@ void print_version(FILE *stream, struct argp_state * /*state*/) {
   fprintf(stream, "%s.%s.%s\n", std::to_string(VERSION_MAJOR).c_str(),
           std::to_string(VERSION_MINOR).c_str(),
           std::to_string(VERSION_PATCH).c_str());
+}
+
+static void send_with_new_api(struct ft_arguments &arguments)
+{
+  std::list<std::shared_ptr<LibFlute::Transmitter::FileDescription> > files;
+
+  for (int j = 0; arguments.files[j]; j++) {
+    auto fd = new LibFlute::Transmitter::FileDescription(arguments.files[j], arguments.files[j]);
+    fd->set_content_type("application/octet-stream");
+    fd->set_expiry_time(std::chrono::system_clock::now() + 60s);
+    if (arguments.use_gzip) {
+      fd->set_compression(LibFlute::Transmitter::FileDescription::COMPRESSION_GZIP);
+    }
+    files.emplace_back(fd);
+  }
+
+  // Create a Boost io_service
+  boost::asio::io_service io;
+
+  // Construct the transmitter class
+  LibFlute::Transmitter transmitter(
+        arguments.mcast_target,
+        (short)arguments.mcast_port,
+        arguments.tsi,
+        arguments.mtu,
+        arguments.rate_limit,
+        io, std::nullopt, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+
+  // Configure IPSEC ESP, if enabled
+  if (arguments.enable_ipsec)
+  {
+    transmitter.enable_ipsec(1, arguments.aes_key);
+  }
+
+  // Register a completion callback
+  transmitter.register_completion_callback(
+        [&files](uint32_t toi) {
+          for (auto& file : files) {
+            if (file->toi() == toi) {
+              spdlog::info("{} (TOI {}) has been transmitted", file->file_entry().content_location, file->toi());
+              // could file.reset() to free the FileDescription here.
+            }
+          }
+        });
+
+  // Queue all the files 
+  for (const auto& file : files) {
+    auto toi = transmitter.send( file );
+    const auto &file_entry = file->file_entry();
+    spdlog::info("Queued {} ({} bytes ({} bytes transmitted)) for transmission, TOI is {}",
+          file_entry.content_location, file_entry.content_length, file_entry.transfer_length, toi);
+  }
+
+  // Start the io_service, and thus sending data
+  io.run();
+}
+
+static void send_with_old_api(struct ft_arguments &arguments)
+{
+  // We're responsible for buffer management, so create a vector of structs that
+  // are going to hold the data buffers
+  struct FsFile {
+    std::string location;
+    char* buffer;
+    size_t len;
+    uint32_t toi;
+  };
+  std::vector<FsFile> files;
+
+  // read the file contents into the buffers
+  for (int j = 0; arguments.files[j]; j++) {
+    const std::string &location = arguments.files[j];
+    std::ifstream file(location, std::ios::binary | std::ios::ate);
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    char* buffer = (char*)malloc(size);
+    file.read(buffer, size);
+    files.push_back(FsFile{ location, buffer, (size_t)size});
+  }
+
+  // Create a Boost io_service
+  boost::asio::io_service io;
+
+  // Construct the transmitter class
+  LibFlute::Transmitter transmitter(
+        arguments.mcast_target,
+        (short)arguments.mcast_port,
+        arguments.tsi,
+        arguments.mtu,
+        arguments.rate_limit,
+        io, std::nullopt, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+
+  // Configure IPSEC ESP, if enabled
+  if (arguments.enable_ipsec) 
+  {
+    transmitter.enable_ipsec(1, arguments.aes_key);
+  }
+
+  // Register a completion callback
+  transmitter.register_completion_callback(
+        [&files](uint32_t toi) {
+          for (auto& file : files) {
+            if (file.toi == toi) { 
+              spdlog::info("{} (TOI {}) has been transmitted", file.location, file.toi);
+              // could free() the buffer here
+            }
+          }
+        });
+
+  // Queue all the files 
+  for (auto& file : files) {
+    file.toi = transmitter.send( file.location,
+          "application/octet-stream",
+          transmitter.seconds_since_epoch() + 60, // 1 minute from now
+          file.buffer,
+          file.len
+          );
+    spdlog::info("Queued {} ({} bytes) for transmission, TOI is {}",
+          file.location, file.len, file.toi);
+  }
+
+  // Start the io_service, and thus sending data
+  io.run();
 }
 
 /**
@@ -145,72 +291,11 @@ auto main(int argc, char **argv) -> int {
   spdlog::info("FLUTE transmitter demo starting up");
 
   try {
-    // We're responsible for buffer management, so create a vector of structs that
-    // are going to hold the data buffers
-    struct FsFile {
-      std::string location;
-      char* buffer;
-      size_t len;
-      uint32_t toi;
-    };
-    std::vector<FsFile> files;
-
-    // read the file contents into the buffers
-    for (int j = 0; arguments.files[j]; j++) {
-      std::string location = arguments.files[j];
-      std::ifstream file(arguments.files[j], std::ios::binary | std::ios::ate);
-      std::streamsize size = file.tellg();
-      file.seekg(0, std::ios::beg);
-
-      char* buffer = (char*)malloc(size);
-      file.read(buffer, size);
-      files.push_back(FsFile{ arguments.files[j], buffer, (size_t)size});
+    if (arguments.new_api) {
+      send_with_new_api(arguments);
+    } else {
+      send_with_old_api(arguments);
     }
-
-    // Create a Boost io_service
-    boost::asio::io_service io;
-
-    // Construct the transmitter class
-    LibFlute::Transmitter transmitter(
-        arguments.mcast_target,
-        (short)arguments.mcast_port,
-        16,
-        arguments.mtu,
-        arguments.rate_limit,
-        io, std::nullopt, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
-
-    // Configure IPSEC ESP, if enabled
-    if (arguments.enable_ipsec) 
-    {
-      transmitter.enable_ipsec(1, arguments.aes_key);
-    }
-
-    // Register a completion callback
-    transmitter.register_completion_callback(
-        [&files](uint32_t toi) {
-        for (auto& file : files) {
-        if (file.toi == toi) { 
-        spdlog::info("{} (TOI {}) has been transmitted",
-            file.location, file.toi);
-        // could free() the buffer here
-        }
-        }
-        });
-
-    // Queue all the files 
-    for (auto& file : files) {
-      file.toi = transmitter.send( file.location,
-          "application/octet-stream",
-          transmitter.seconds_since_epoch() + 60, // 1 minute from now
-          file.buffer,
-          file.len
-          );
-      spdlog::info("Queued {} ({} bytes) for transmission, TOI is {}",
-          file.location, file.len, file.toi);
-    }
-
-    // Start the io_service, and thus sending data
-    io.run();
   } catch (std::exception ex ) {
     spdlog::error("Exiting on unhandled exception: %s", ex.what());
   }

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -29,12 +29,14 @@
 
 #include <libconfig.h++>
 #include <boost/asio.hpp>
+#include <openssl/sha.h>
 
 #include "spdlog/async.h"
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/syslog_sink.h"
 
 #include "Version.h"
+#include "../utils/base64.h"
 #include "Transmitter.h"
 
 
@@ -62,7 +64,8 @@ static struct argp_option options[] = {  // NOLINT
     {"gzip", 'g', nullptr, 0, "Use gzip to compress the contents, implies -n option", 0},
     {"tsi", 'T', "ID", 0, "The TSI to use for the FLUTE session (default: 16)", 0},
     {"new-api", 'n', nullptr, 0, "Use the new FileDescription API", 0},
-    {"retransmit", 'R', "COUNT", 0, "Number of times to repeatedly transmit a file (default: 1)", 0},
+    {"retransmit", 'R', "COUNT", 0, "Number of times to repeatedly transmit a file, implies -n option (default: 1)", 0},
+    {"etags", 'e', nullptr, 0, "Enable generation of ETag values for each file, implies -n option (default: no ETags)", 0},
     {nullptr, 0, nullptr, 0, nullptr, 0}};
 
 /**
@@ -73,6 +76,7 @@ struct ft_arguments {
   bool enable_ipsec = false;
   bool use_gzip = false;
   bool new_api = false;
+  bool gen_etags = false;
   const char *aes_key = {};
   unsigned short mcast_port = 40085;
   unsigned short mtu = 1500;
@@ -89,6 +93,10 @@ struct ft_arguments {
 static auto parse_opt(int key, char *arg, struct argp_state *state) -> error_t {
   auto arguments = static_cast<struct ft_arguments *>(state->input);
   switch (key) {
+    case 'e':
+      arguments->gen_etags = true;
+      arguments->new_api = true;
+      break;
     case 'm':
       arguments->mcast_target = arg;
       break;
@@ -120,6 +128,7 @@ static auto parse_opt(int key, char *arg, struct argp_state *state) -> error_t {
       break;
     case 'R':
       arguments->retransmit_count = static_cast<size_t>(strtoul(arg, nullptr, 10));
+      arguments->new_api = true;
       break;
     case ARGP_KEY_NO_ARGS:
       argp_usage (state);
@@ -150,6 +159,7 @@ static void send_with_new_api(struct ft_arguments &arguments)
 {
   struct fileEntry {
     fileEntry(LibFlute::Transmitter::FileDescription *fd, size_t init_count = 0) :file(fd), transmitted_count(init_count) {};
+
     std::shared_ptr<LibFlute::Transmitter::FileDescription> file;
     size_t transmitted_count;
   };
@@ -162,6 +172,11 @@ static void send_with_new_api(struct ft_arguments &arguments)
     fd->set_expiry_time(std::chrono::system_clock::now() + 60s);
     if (arguments.use_gzip) {
       fd->set_compression(LibFlute::Transmitter::FileDescription::COMPRESSION_GZIP);
+    }
+    if (arguments.gen_etags) {
+      std::array<unsigned char, SHA_DIGEST_LENGTH> digest;
+      SHA1(reinterpret_cast<const unsigned char*>(fd->data()), fd->data_length(), digest.data());
+      fd->set_etag(base64_encode(digest.data(), SHA_DIGEST_LENGTH));
     }
     files.emplace_back(fd);
   }

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -62,6 +62,7 @@ static struct argp_option options[] = {  // NOLINT
     {"gzip", 'g', nullptr, 0, "Use gzip to compress the contents, implies -n option", 0},
     {"tsi", 'T', "ID", 0, "The TSI to use for the FLUTE session (default: 16)", 0},
     {"new-api", 'n', nullptr, 0, "Use the new FileDescription API", 0},
+    {"retransmit", 'R', "COUNT", 0, "Number of times to repeatedly transmit a file (default: 1)", 0},
     {nullptr, 0, nullptr, 0, nullptr, 0}};
 
 /**
@@ -77,6 +78,7 @@ struct ft_arguments {
   unsigned short mtu = 1500;
   uint32_t rate_limit = 1000;
   uint64_t tsi = 16;
+  size_t retransmit_count = 1;
   unsigned log_level = 2;        /**< log level */
   char **files;
 };
@@ -116,6 +118,9 @@ static auto parse_opt(int key, char *arg, struct argp_state *state) -> error_t {
     case 'n':
       arguments->new_api = true;
       break;
+    case 'R':
+      arguments->retransmit_count = static_cast<size_t>(strtoul(arg, nullptr, 10));
+      break;
     case ARGP_KEY_NO_ARGS:
       argp_usage (state);
     case ARGP_KEY_ARG:
@@ -143,7 +148,13 @@ void print_version(FILE *stream, struct argp_state * /*state*/) {
 
 static void send_with_new_api(struct ft_arguments &arguments)
 {
-  std::list<std::shared_ptr<LibFlute::Transmitter::FileDescription> > files;
+  struct fileEntry {
+    fileEntry(LibFlute::Transmitter::FileDescription *fd, size_t init_count = 0) :file(fd), transmitted_count(init_count) {};
+    std::shared_ptr<LibFlute::Transmitter::FileDescription> file;
+    size_t transmitted_count;
+  };
+    
+  std::list<fileEntry> files;
 
   for (int j = 0; arguments.files[j]; j++) {
     auto fd = new LibFlute::Transmitter::FileDescription(arguments.files[j], arguments.files[j]);
@@ -175,19 +186,22 @@ static void send_with_new_api(struct ft_arguments &arguments)
 
   // Register a completion callback
   transmitter.register_completion_callback(
-        [&files](uint32_t toi) {
-          for (auto& file : files) {
-            if (file->toi() == toi) {
-              spdlog::info("{} (TOI {}) has been transmitted", file->file_entry().content_location, file->toi());
-              // could file.reset() to free the FileDescription here.
+        [&files, &arguments, &transmitter](uint32_t toi) {
+          for (auto& f : files) {
+            if (f.file->toi() == toi) {
+              spdlog::info("{} (TOI {}) has been transmitted", f.file->file_entry().content_location, f.file->toi());
+              f.transmitted_count++;
+              if (f.transmitted_count < arguments.retransmit_count) {
+		transmitter.send(f.file);
+              }
             }
           }
         });
 
   // Queue all the files 
   for (const auto& file : files) {
-    auto toi = transmitter.send( file );
-    const auto &file_entry = file->file_entry();
+    auto toi = transmitter.send( file.file );
+    const auto &file_entry = file.file->file_entry();
     spdlog::info("Queued {} ({} bytes ({} bytes transmitted)) for transmission, TOI is {}",
           file_entry.content_location, file_entry.content_length, file_entry.fec_oti.transfer_length, toi);
   }

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -189,7 +189,7 @@ static void send_with_new_api(struct ft_arguments &arguments)
     auto toi = transmitter.send( file );
     const auto &file_entry = file->file_entry();
     spdlog::info("Queued {} ({} bytes ({} bytes transmitted)) for transmission, TOI is {}",
-          file_entry.content_location, file_entry.content_length, file_entry.transfer_length, toi);
+          file_entry.content_location, file_entry.content_length, file_entry.fec_oti.transfer_length, toi);
   }
 
   // Start the io_service, and thus sending data

--- a/include/File.h
+++ b/include/File.h
@@ -102,6 +102,11 @@ namespace LibFlute {
       void decode();
 
      /**
+      *  Check if the buffer is content encoded
+      */
+      bool is_encoded() const { return _been_encoded || !_been_decoded; };
+
+     /**
       *  Get the FEC OTI values
       */
       const FecOti& fec_oti() const { return _meta.fec_oti; };

--- a/include/File.h
+++ b/include/File.h
@@ -90,6 +90,11 @@ namespace LibFlute {
       size_t length() const { return _been_decoded?_meta.content_length:_meta.fec_oti.transfer_length; };
 
      /**
+      *  Encode the buffer using the Content-Encoding
+      */
+      void encode();
+
+     /**
       *  Decode the buffer using the Content-Encoding
       *
       *  Will check the MD5 sum after decoding, if present.
@@ -171,6 +176,7 @@ namespace LibFlute {
 
       char* _buffer = nullptr;
       bool _own_buffer = false;
+      bool _been_encoded = false;
       bool _been_decoded = false;
 
       LibFlute::FileDeliveryTable::FileEntry _meta;

--- a/include/File.h
+++ b/include/File.h
@@ -9,7 +9,7 @@
 // agreed to in writing, software distributed under the License is distributed on
 // an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.
-// 
+//
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
@@ -21,6 +21,7 @@
 #include "AlcPacket.h"
 #include "FileDeliveryTable.h"
 #include "EncodingSymbol.h"
+#include "Transmitter.h"
 
 namespace LibFlute {
   /**
@@ -36,6 +37,13 @@ namespace LibFlute {
       File(LibFlute::FileDeliveryTable::FileEntry entry);
 
      /**
+      *  Create a file from a Transmitter::FileDescription (used for transmission)
+      *
+      *  @param file_description Transmitter File Description
+      */
+      File(const std::shared_ptr<Transmitter::FileDescription> &file_description);
+
+     /**
       *  Create a file from the given parameters (used for transmission)
       *
       *  @param toi TOI of the file
@@ -44,10 +52,10 @@ namespace LibFlute {
       *  @param expires Expiry value (in seconds since the NTP epoch)
       *  @param data Pointer to the data buffer
       *  @param length Length of the buffer
-      *  @param copy_data Copy the buffer. If false (the default), the caller must ensure the buffer remains valid 
+      *  @param copy_data Copy the buffer. If false (the default), the caller must ensure the buffer remains valid
       *                   while the file is being transmitted.
       */
-      File(uint32_t toi, 
+      File(uint32_t toi,
           FecOti fec_oti,
           std::string content_location,
           std::string content_type,
@@ -79,7 +87,14 @@ namespace LibFlute {
      /**
       *  Get the data buffer length
       */
-      size_t length() const { return _meta.fec_oti.transfer_length; };
+      size_t length() const { return _been_decoded?_meta.content_length:_meta.fec_oti.transfer_length; };
+
+     /**
+      *  Decode the buffer using the Content-Encoding
+      *
+      *  Will check the MD5 sum after decoding, if present.
+      */
+      void decode();
 
      /**
       *  Get the FEC OTI values
@@ -156,11 +171,14 @@ namespace LibFlute {
 
       char* _buffer = nullptr;
       bool _own_buffer = false;
+      bool _been_decoded = false;
 
       LibFlute::FileDeliveryTable::FileEntry _meta;
       unsigned long _received_at;
       unsigned _access_count = 0;
 
       uint16_t _fdt_instance_id = 0;
+
+      std::shared_ptr<Transmitter::FileDescription> _file_description;
   };
 };

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -84,7 +84,9 @@ namespace LibFlute {
         } cache_control;
         std::string content_encoding;
         std::string etag;
-        uint32_t transfer_length;
+
+        bool operator==(const FileEntry &other) const;
+        bool operator!=(const FileEntry &other) const { return !(*this == other); };
       };
 
      /**

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <stddef.h>
 #include <stdint.h>
+#include <optional>
 #include <string>
 #include <vector>
 #include "flute_types.h"
@@ -77,6 +78,13 @@ namespace LibFlute {
         std::string content_type;
         uint64_t expires;
         FecOti fec_oti;
+        struct {
+          bool no_cache;
+          std::optional<uint64_t> cache_expires;
+        } cache_control;
+        std::string content_encoding;
+        std::string etag;
+        uint32_t transfer_length;
       };
 
      /**
@@ -102,7 +110,9 @@ namespace LibFlute {
      /**
       *  Get all current file entries
       */
-      std::vector<FileEntry> file_entries() { return _file_entries; };
+      const std::vector<FileEntry> &file_entries() const {
+        return _file_entries;
+      };
 
     private:
       uint32_t _instance_id;

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -64,6 +64,7 @@ namespace LibFlute {
         */
         FileDescription(const std::string &content_location, const std::string &filename);
 
+       /**@{*/
        /**
         * Make a file description using the contents of a vector
         *
@@ -75,6 +76,8 @@ namespace LibFlute {
         * @param data The vector containing the file contents
         */
         FileDescription(const std::string &content_location, const std::vector<char> &data);
+        FileDescription(const std::string &content_location, const std::vector<unsigned char> &data);
+       /**@}*/
 
        /**
         * Make a file description using the contents of a memory buffer
@@ -218,6 +221,13 @@ namespace LibFlute {
         * @return this file description
         */
         FileDescription &set_compression(CompressionAlgorithm compression);
+
+       /**
+        * Set Content-Location
+        *
+        * @param location The location URL or filename.
+        */
+        FileDescription &set_content_location(const std::string &location);
 
        /**
         * Change the file contents using a local file

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -216,6 +216,7 @@ namespace LibFlute {
         * Set the compression algorithm
         *
         * This sets the compression algorithm that will be used to compress the file contents before sending.
+        * This will reset the TOI if the compression algorithm is changed.
         *
         * @param compression The compression algorithm to set
         * @return this file description
@@ -233,6 +234,7 @@ namespace LibFlute {
         * Change the file contents using a local file
         *
         * This will alter the contents associated with this file description and replace them with the contents of the local file.
+        * This will reset the TOI if the contents have changed.
         *
         * @param filename The local file path for the new contents
         * @return this file description
@@ -245,6 +247,7 @@ namespace LibFlute {
         * This will alter the contents associated with this file description and replace them with a reference to the memory buffer.
         * It is up to the application to ensure that the data is retained in memory until it has finished with this file
         * description and the Transmitter has finished sending the file.
+        * This will reset the TOI if the contents have changed.
         *
         * @param data The in memory buffer to use for the new file contents
         * @param data_length The length of the contents in the memory buffer
@@ -259,6 +262,7 @@ namespace LibFlute {
         * This will alter the contents associated with this file description and replace them with a reference to the contents of
         * the vector. It is up to the application to ensure that the data is retained in memory until it has finished with this
         * file description and the Transmitter has finished sending the file.
+        * This will reset the TOI if the contents have changed.
         *
         * @param data The vector to use for the new file contents
         * @return this file description

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -282,6 +282,23 @@ namespace LibFlute {
         */
         date_time_type get_expiry_time() const;
 
+       /**
+        *  Set the ETag value for the file
+        *
+        *  Set to the empty string to remove the ETag.
+        *
+        *  @param etag The ETag to set
+        *  @return this file description
+        */
+        FileDescription &set_etag(const std::string &etag);
+
+       /**
+        *  Get the current ETag value
+        *
+        *  @return The current ETag value for the file
+        */
+        const std::string &get_etag() const;
+
       protected:
         friend class Transmitter;
        /**

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -51,7 +51,8 @@ namespace LibFlute {
 
         enum CompressionAlgorithm {
           COMPRESSION_NONE = 0,  //< No compression
-          COMPRESSION_GZIP       //< Use gzip compression when encoding the file
+          COMPRESSION_GZIP,      //< Use gzip compression when encoding the file
+          COMPRESSION_DEFLATE    //< Use deflate compression when encoding the file
         };
 
         FileDescription() = delete;
@@ -311,8 +312,6 @@ namespace LibFlute {
         void _attach_file(const std::string &filename);
         void _free_file_data();
         void _calculate_file_entry();
-        void _compress_data();
-        void _gzip_data();
 
         std::optional<uint64_t> _tsi; //< The last TSI this file was associated with
         FileDeliveryTable::FileEntry _file_entry; //< The FDT File entry values to use
@@ -321,8 +320,6 @@ namespace LibFlute {
         int _file_handle;                         //< The file handle of the open _filename
         const char *_data;                        //< The uncompressed file contents (may be mapped file)
         size_t _data_length;                      //< The length of the uncompressed file contents
-        char *_transfer_data;                     //< The compressed file contents or `NULL` if compression has not been applied or is not needed
-        size_t _transfer_length;                  //< Length in bytes of the compressed contents if _transfer_data is not `NULL`.
       };
 
      /**

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -17,16 +17,20 @@
 #pragma once
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>
+#include <chrono>
 #include <queue>
 #include <string>
 #include <map>
 #include <mutex>
 #include <optional>
-#include "File.h"
+//#include "File.h"
 #include "AlcPacket.h"
 #include "FileDeliveryTable.h"
 
 namespace LibFlute {
+
+  class File;
+
   /**
    *  FLUTE transmitter class. Construct an instance of this to send data through a FLUTE/ALC session.
    */
@@ -36,6 +40,290 @@ namespace LibFlute {
       * FDT namespace enumeration
       */
       using FdtNamespace = FileDeliveryTable::FdtNamespace;
+
+
+     /**
+      * File Description object
+      */
+      class FileDescription {
+      public:
+        using date_time_type = std::chrono::system_clock::time_point;
+
+        enum CompressionAlgorithm {
+          COMPRESSION_NONE = 0,  //< No compression
+          COMPRESSION_GZIP       //< Use gzip compression when encoding the file
+        };
+
+        FileDescription() = delete;
+       /**
+        * Make a file description using the contents of a local file
+        *
+        * @param content_location The URL to use as the content location in the FDT when sending the file
+        * @param filename The filename in the local filesystem of the file contents associated with this file description
+        */
+        FileDescription(const std::string &content_location, const std::string &filename);
+
+       /**
+        * Make a file description using the contents of a vector
+        *
+        * This does not copy the data, it only retains a reference to it. It is up to the application to ensure that the
+        * data is retained in memory until it has finished with this file description and the Transmitter has finished sending
+        * the file.
+        *
+        * @param content_location The URL to use as the content location in the FDT when sending the file
+        * @param data The vector containing the file contents
+        */
+        FileDescription(const std::string &content_location, const std::vector<char> &data);
+
+       /**
+        * Make a file description using the contents of a memory buffer
+        *
+        * This does not copy the data, it only retains a reference to it. It is up to the application to ensure that the
+        * data is retained in memory until it has finished with this file description and the Transmitter has finished sending
+        * the file.
+        *
+        * @param content_location The URL to use as the content location in the FDT when sending the file
+        * @param data A pointer to the memory buffer containing the file contents
+        * @param length The size of the file contents in the memory buffer in bytes
+        */
+        FileDescription(const std::string &content_location, const char *data, size_t length);
+
+       /**
+        * Make a file description without contents
+        *
+        * Create a file description with just a URL location and no body content. The content can be added later using the
+        * set_content() methods.
+        *
+        * @param content_location The URL to use as the content location in the FDT when sending the file
+        * @see set_content()
+        */
+        FileDescription(const std::string &content_location);
+
+       /**
+        * Copy constructor
+        *
+        * This will make a copy of the file description.
+        *
+        * @param other The other file description to copy
+        */
+        FileDescription(const FileDescription &other);
+
+       /**
+        * Move constructor
+        *
+        * This will move the resources of the other file description into a new file description.
+        *
+        * @param other The other file description to move
+        */
+        FileDescription(FileDescription &&other);
+
+       /**
+        * Destructor
+        *
+        * Free all resources associated with this file description.
+        */
+        virtual ~FileDescription();
+
+       /**
+        * Copy operator
+        *
+        * This will make a copy of the other file description into this one.
+        *
+        * @param other The other file description to copy
+        *
+        * @return this file description
+        */
+        FileDescription &operator=(const FileDescription &other);
+
+       /**
+        * Move operator
+        *
+        * This will move the resources of the other file description into this one.
+        *
+        * @param other The other file description to move into this
+        *
+        * @return this file description
+        */
+        FileDescription &operator=(FileDescription &&other);
+
+       /**
+        * Equality operator
+        *
+        * Check if two file descriptions are equivalent
+        */
+        bool operator==(const FileDescription &other) const;
+
+       /**
+        * Has a Transmitter associated a TSI with this file?
+        *
+        * @return `true` if the TSI has been set
+        */
+        bool has_tsi() const { return _tsi.has_value(); };
+
+       /**
+        * Get the associated TSI value
+        *
+        * @return the TSI value associated with this file description or 0 if not set
+        * @see has_tsi()
+        */
+        uint64_t tsi() const { return _tsi?_tsi.value():0; };
+
+       /**
+        * Get the TOI associated with this file description
+        *
+        * This is meaningless if has_tsi() is false.
+        *
+        * @return the TOI associated with this file description
+        */
+        uint32_t toi() const { return _file_entry.toi; };
+
+       /**
+        * Get the FDT file entry
+        *
+        * @return The current FDT File entry
+        */
+        const FileDeliveryTable::FileEntry &file_entry() const {
+          return _file_entry;
+        };
+
+       /**
+        * Get the data to be transmitted
+        *
+        * This will apply the compression standard currently set to the contents and provide a transfer buffer.
+        *
+        * @return The transfer data buffer pointer for the file contents. Use data_length() to get the transfer buffer size
+        * @see set_compression()
+        * @see data_length()
+        */
+        const char *data();
+
+       /**
+        * Get the length in bytes of the data to be transmitted
+        *
+        * This will apply the compression standard currently set to the contents and provide the resulting transfer buffer length.
+        *
+        * @return The transfer data buffer length in bytes. Use data() to get the transfer buffer pointer
+        * @see set_compression()
+        * @see data()
+        */
+        size_t data_length();
+
+       /**
+        * Set the compression algorithm
+        *
+        * This sets the compression algorithm that will be used to compress the file contents before sending.
+        *
+        * @param compression The compression algorithm to set
+        * @return this file description
+        */
+        FileDescription &set_compression(CompressionAlgorithm compression);
+
+       /**
+        * Change the file contents using a local file
+        *
+        * This will alter the contents associated with this file description and replace them with the contents of the local file.
+        *
+        * @param filename The local file path for the new contents
+        * @return this file description
+        */
+        FileDescription &set_content(const std::string &filename);
+
+       /**
+        * Change the file contents using a memory buffer
+        *
+        * This will alter the contents associated with this file description and replace them with a reference to the memory buffer.
+        * It is up to the application to ensure that the data is retained in memory until it has finished with this file
+        * description and the Transmitter has finished sending the file.
+        *
+        * @param data The in memory buffer to use for the new file contents
+        * @param data_length The length of the contents in the memory buffer
+        * @return this file description
+        */
+        FileDescription &set_content(const char *data, size_t data_length);
+
+       /**@{*/
+       /**
+        * Change the file contents using a vector
+        *
+        * This will alter the contents associated with this file description and replace them with a reference to the contents of
+        * the vector. It is up to the application to ensure that the data is retained in memory until it has finished with this
+        * file description and the Transmitter has finished sending the file.
+        *
+        * @param data The vector to use for the new file contents
+        * @return this file description
+        */
+        FileDescription &set_content(const std::vector<char> &data);
+        FileDescription &set_content(const std::vector<unsigned char> &data);
+       /**@}*/
+
+       /**
+        * Change the file content type
+        *
+        * This will set the `Content-Type` that is associated with this file.
+        *
+        * @param content_type The content type to set.
+        * @return this file description
+        */
+        FileDescription &set_content_type(const std::string &content_type);
+
+       /**
+        * Change the file expiry time
+        *
+        * @param expiry_time The expiry time of the file in the FLUTE session.
+        * @return this file description
+        */
+        FileDescription &set_expiry_time(const date_time_type &expiry_time);
+
+       /**
+        *  Get the currently set expiry time
+        *
+        *  @return the expiry time of this file.
+        */
+        date_time_type get_expiry_time() const;
+
+      protected:
+        friend class Transmitter;
+       /**
+        * Set the TSI (used by the Transmitter class)
+        *
+        * @param val The new TSI value
+        * @return this file description
+        */
+        FileDescription &tsi(uint64_t val) { _tsi = val; return *this; };
+       /**
+        * Set the TOI (used by the Transmitter class)
+        *
+        * @param val The new TOI value
+        * @return this file description
+        */
+        FileDescription &toi(uint32_t val) { _file_entry.toi = val; return *this; };
+
+       /**
+        * Merge the FecOti values
+        *
+        * Takes any values that are unset in _file_entry.fec_oti from @p fec_oti.
+        *
+        * @param fec_oti The FecOti to merge values from.
+        */
+        FileDescription &merge_fec_oti(const FecOti &fec_oti);
+
+      private:
+        void _attach_file(const std::string &filename);
+        void _free_file_data();
+        void _calculate_file_entry();
+        void _compress_data();
+        void _gzip_data();
+
+        std::optional<uint64_t> _tsi; //< The last TSI this file was associated with
+        FileDeliveryTable::FileEntry _file_entry; //< The FDT File entry values to use
+        CompressionAlgorithm _compression_type;   //< The compression to apply to _data
+        std::string _filename;                    //< The filename that _data was loaded from, empty for no local file
+        int _file_handle;                         //< The file handle of the open _filename
+        const char *_data;                        //< The uncompressed file contents (may be mapped file)
+        size_t _data_length;                      //< The length of the uncompressed file contents
+        char *_transfer_data;                     //< The compressed file contents or `NULL` if compression has not been applied or is not needed
+        size_t _transfer_length;                  //< Length in bytes of the compressed contents if _transfer_data is not `NULL`.
+      };
 
      /**
       *  Definition of a file transmission completion callback function that can be
@@ -78,7 +366,10 @@ namespace LibFlute {
       void enable_ipsec( uint32_t spi, const std::string& aes_key);
 
      /**
-      *  Transmit a file. 
+      *  Transmit a file (deprecated).
+      *
+      *  @deprecated send(FileDescription*) should be used instead.
+      *
       *  The caller must ensure the data buffer passed here remains valid until the completion callback 
       *  for this file is called.
       *
@@ -95,6 +386,22 @@ namespace LibFlute {
           uint32_t expires,
           char* data,
           size_t length);
+
+     /**
+      *  Transmit a file.
+      *  The caller must ensure the file description passed here remains valid until the completion callback
+      *  for this file description is called.
+      *
+      *  The file description object passed in @a file_description may be updated by the Transmitter until the
+      *  completion callback for this file description is called.
+      *
+      *  If a file description is reused then the TOI of the previous use is reused. This allows resends or
+      *  updates to existing files to be transmitted.
+      *
+      *  @param file_description The file description object for the file to send
+      *  @return TOI of the file.
+      */
+      uint16_t send(const std::shared_ptr<FileDescription> &file_description);
 
      /**
       *  Convenience function to get the current timestamp for expiry calculation
@@ -127,8 +434,8 @@ namespace LibFlute {
       uint64_t _tsi;
       uint16_t _mtu;
 
-      std::unique_ptr<LibFlute::FileDeliveryTable> _fdt;
-      std::map<uint32_t, std::shared_ptr<LibFlute::File>> _files;
+      std::unique_ptr<FileDeliveryTable> _fdt;
+      std::map<uint32_t, std::shared_ptr<File>> _files;
       std::mutex _files_mutex;
 
       unsigned _fdt_repeat_interval = 5;
@@ -144,4 +451,5 @@ namespace LibFlute {
       std::optional<boost::asio::ip::udp::endpoint> _tunnel_endpoint = std::nullopt;
       boost::asio::ip::address _tunnel_local_address;
   };
-};
+
+} // end namespace LibFlute

--- a/include/flute_types.h
+++ b/include/flute_types.h
@@ -50,8 +50,17 @@ namespace LibFlute {
    */
   struct FecOti {
     FecScheme encoding_id;
+    uint32_t instance_id;
     uint64_t transfer_length;
     uint32_t encoding_symbol_length;
     uint32_t max_source_block_length;
+    uint32_t max_number_of_encoding_symbols;
+
+    bool operator==(const FecOti &other) const {
+      return encoding_id == other.encoding_id && transfer_length == other.transfer_length &&
+             encoding_symbol_length == other.encoding_symbol_length && max_source_block_length == other.max_source_block_length &&
+             max_number_of_encoding_symbols == other.max_number_of_encoding_symbols;
+    };
+    bool operator!=(const FecOti &other) const { return !(*this == other); };
   };
 };

--- a/src/EncodingSymbol.cpp
+++ b/src/EncodingSymbol.cpp
@@ -26,8 +26,8 @@ auto LibFlute::EncodingSymbol::from_payload(char* encoded_data, size_t data_len,
   auto encoding_symbol_id = 0;
   std::vector<EncodingSymbol> symbols;
 
-  if (encoding != ContentEncoding::NONE) {
-    throw "Only unencoded content is supported";
+  if (encoding != ContentEncoding::NONE && encoding != ContentEncoding::GZIP) {
+    throw "Only unencoded or gzipped content is supported";
   }
   
   if (fec_oti.encoding_id == FecScheme::CompactNoCode) {
@@ -57,12 +57,13 @@ auto LibFlute::EncodingSymbol::to_payload(const std::vector<EncodingSymbol>& sym
   size_t len = 0;
   auto ptr = encoded_data;
   auto first_symbol = symbols.begin();
-  if (fec_oti.encoding_id == FecScheme::CompactNoCode) {
+  if (fec_oti.encoding_id == FecScheme::CompactNoCode && data_len >= 4) {
     *((uint16_t*)ptr) = htons(first_symbol->source_block_number());
     ptr += 2;
     *((uint16_t*)ptr) = htons(first_symbol->id());
     ptr += 2;
     len += 4;
+    data_len -= 4;
   } else {
     throw "Only compact no-code FEC is supported";
   }

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
-#include "File.h"
 #include <iostream>
 #include <string>
 #include <cstring>
@@ -25,12 +24,19 @@
 // Suppress warnings about MD5 being deprecated in later versions of OpenSSL
 #define OPENSSL_SUPPRESS_DEPRECATED 1
 #include <openssl/md5.h>
+#include <zlib.h>
+
 #include "base64.h"
 #include "spdlog/spdlog.h"
+#include "Transmitter.h"
+#include "File.h"
 
-LibFlute::File::File(LibFlute::FileDeliveryTable::FileEntry entry)
+namespace LibFlute {
+
+File::File(FileDeliveryTable::FileEntry entry)
   : _meta( std::move(entry) )
   , _received_at( time(nullptr) )
+  , _file_description()
 {
   spdlog::debug("Creating File from FileEntry");
   // Allocate a data buffer
@@ -42,18 +48,48 @@ LibFlute::File::File(LibFlute::FileDeliveryTable::FileEntry entry)
   }
   _own_buffer = true;
 
-  calculate_partitioning();
-  create_blocks();
+  this->calculate_partitioning();
+  this->create_blocks();
 }
 
-LibFlute::File::File(uint32_t toi,
+File::File(const std::shared_ptr<Transmitter::FileDescription> &file_description)
+  : _meta()
+  , _file_description(file_description)
+{
+  spdlog::debug("Creating File from FileDescription");
+
+  auto length = _file_description->data_length();
+  _buffer = new char[length];
+  if (_buffer == nullptr)
+  {
+    throw "No data allocated";
+  }
+  _own_buffer = true;
+  memcpy(_buffer, _file_description->data(), length);
+  _meta = _file_description->file_entry();
+
+  // for no-code
+  if (_meta.fec_oti.encoding_id == FecScheme::CompactNoCode) {
+    _meta.fec_oti.transfer_length = length;
+  } else {
+    throw "Unsupported FEC scheme";
+  }
+
+  this->calculate_partitioning();
+  this->create_blocks();
+}
+
+File::File(uint32_t toi,
     FecOti fec_oti,
     std::string content_location,
     std::string content_type,
     uint64_t expires,
     char* data,
     size_t length,
-    bool copy_data) 
+    bool copy_data)
+  : _own_buffer(false)
+  , _meta()
+  , _file_description()
 {
   spdlog::debug("Creating File from data");
   if (copy_data) {
@@ -87,11 +123,11 @@ LibFlute::File::File(uint32_t toi,
     throw "Unsupported FEC scheme";
   }
 
-  calculate_partitioning();
-  create_blocks();
+  this->calculate_partitioning();
+  this->create_blocks();
 }
 
-LibFlute::File::~File()
+File::~File()
 {
   spdlog::debug("Destroying File");
   if (_own_buffer && _buffer != nullptr)
@@ -101,7 +137,7 @@ LibFlute::File::~File()
   }
 }
 
-auto LibFlute::File::put_symbol( const LibFlute::EncodingSymbol& symbol ) -> void
+auto File::put_symbol( const EncodingSymbol& symbol ) -> void
 {
   if (symbol.source_block_number() > _source_blocks.size()) {
     throw "Source Block number too high";
@@ -125,17 +161,17 @@ auto LibFlute::File::put_symbol( const LibFlute::EncodingSymbol& symbol ) -> voi
 
 }
 
-auto LibFlute::File::check_source_block_completion( SourceBlock& block ) -> void
+auto File::check_source_block_completion( SourceBlock& block ) -> void
 {
   block.complete = std::all_of(block.symbols.begin(), block.symbols.end(), [](const auto& symbol){ return symbol.second.complete; });
 }
 
-auto LibFlute::File::check_file_completion() -> void
+auto File::check_file_completion() -> void
 {
   _complete = std::all_of(_source_blocks.begin(), _source_blocks.end(), [](const auto& block){ return block.second.complete; });
 
-  if (_complete && !_meta.content_md5.empty()) {
-    //check MD5 sum
+  if (_complete && !_meta.content_md5.empty() && _meta.content_encoding.empty()) {
+    //check MD5 sum if we haven't encoded the contents
     unsigned char md5[MD5_DIGEST_LENGTH];
     MD5((const unsigned char*)buffer(), length(), md5);
 
@@ -155,7 +191,7 @@ auto LibFlute::File::check_file_completion() -> void
   }
 }
 
-auto LibFlute::File::calculate_partitioning() -> void
+auto File::calculate_partitioning() -> void
 {
   // Calculate source block partitioning (RFC5052 9.1) 
   _nof_source_symbols = ceil((double)_meta.fec_oti.transfer_length / (double)_meta.fec_oti.encoding_symbol_length);
@@ -165,7 +201,7 @@ auto LibFlute::File::calculate_partitioning() -> void
   _nof_large_source_blocks = _nof_source_symbols - _small_source_block_length * _nof_source_blocks;
 }
 
-auto LibFlute::File::create_blocks() -> void
+auto File::create_blocks() -> void
 {
   // Create the required source blocks and encoding symbols
   auto buffer_ptr = _buffer;
@@ -192,7 +228,7 @@ auto LibFlute::File::create_blocks() -> void
   }
 }
 
-auto LibFlute::File::get_next_symbols(size_t max_size) -> std::vector<EncodingSymbol> 
+auto File::get_next_symbols(size_t max_size) -> std::vector<EncodingSymbol> 
 {
   int nof_symbols = std::ceil((float)(max_size - 4) / (float)_meta.fec_oti.encoding_symbol_length);
   auto cnt = 0;
@@ -217,7 +253,7 @@ auto LibFlute::File::get_next_symbols(size_t max_size) -> std::vector<EncodingSy
 
 }
 
-auto LibFlute::File::mark_completed(const std::vector<EncodingSymbol>& symbols, bool success) -> void
+auto File::mark_completed(const std::vector<EncodingSymbol>& symbols, bool success) -> void
 {
   for (auto& symbol : symbols) {
     auto block = _source_blocks.find(symbol.source_block_number());
@@ -232,3 +268,76 @@ auto LibFlute::File::mark_completed(const std::vector<EncodingSymbol>& symbols, 
     }
   }
 }
+
+auto File::decode() -> void
+{
+  if (!_been_decoded && !_meta.content_encoding.empty()) {
+    if (_meta.content_encoding == "gzip" || _meta.content_encoding=="deflate") {
+      auto comp_buffer = _buffer;
+      bool own_comp = _own_buffer;
+      std::shared_ptr<unsigned char> decomp_buffer(new unsigned char[16384]);
+      z_stream zs = {
+	.next_in = reinterpret_cast<unsigned char*>(comp_buffer),
+	.avail_in = static_cast<uint32_t>(_meta.fec_oti.transfer_length),
+        .next_out = decomp_buffer.get(),
+        .avail_out = 16384
+      };
+      spdlog::debug("Decompressing contents with {}", _meta.content_encoding);
+
+      inflateInit2(&zs, 15 | ((_meta.content_encoding == "gzip")?16:0));
+      _buffer = nullptr;
+      auto zstate = inflate(&zs, Z_FINISH);
+      size_t last_out = 0;
+      while (zstate == Z_OK) {
+        spdlog::debug("Part decompressed: {} bytes", 16384-zs.avail_out);
+        _buffer = reinterpret_cast<char*>(realloc(_buffer, zs.total_out));
+        memcpy(_buffer+last_out, decomp_buffer.get(), 16384-zs.avail_out);
+        last_out = zs.total_out;
+        _own_buffer = true;
+	zs.avail_out = 16384;
+        zs.next_out = decomp_buffer.get();
+	zstate = inflate(&zs, Z_FINISH);
+      }
+      if (zstate==Z_STREAM_END) {
+	if (last_out != zs.total_out) {
+          spdlog::debug("Finish decompress, last block is {} bytes. Total {} bytes", 16384-zs.avail_out, zs.total_out);
+          _buffer = reinterpret_cast<char*>(realloc(_buffer, zs.total_out));
+          memcpy(_buffer+last_out, decomp_buffer.get(), 16384-zs.avail_out);
+          _own_buffer = true;
+        }
+      } else {
+        spdlog::error("Error decompressing file {}: {}", _meta.toi, zs.msg);
+	throw zs.msg;
+      }
+
+      if (own_comp) free(comp_buffer);
+    } else {
+      spdlog::error("Unknown Content-Encoding {}", _meta.content_encoding);
+      throw "Content-Encoding not known";
+    }
+
+    _been_decoded = true;
+
+    // Check MD5
+    if (!_meta.content_md5.empty()) {
+      unsigned char md5[MD5_DIGEST_LENGTH];
+      MD5((const unsigned char*)buffer(), length(), md5);
+
+      auto content_md5 = base64_decode(_meta.content_md5);
+      if (memcmp(md5, content_md5.c_str(), MD5_DIGEST_LENGTH) != 0) {
+        spdlog::debug("MD5 mismatch for TOI {}, discarding", _meta.toi);
+
+        // MD5 mismatch, try again
+        for (auto& block : _source_blocks) {
+          for (auto& symbol : block.second.symbols) {
+            symbol.second.complete = false;
+          }
+          block.second.complete = false;
+        }
+        _complete = false;
+      }
+    }
+  }
+}
+
+} // end namespace LibFlute

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -59,7 +59,7 @@ File::File(const std::shared_ptr<Transmitter::FileDescription> &file_description
   spdlog::debug("Creating File from FileDescription");
 
   auto length = _file_description->data_length();
-  _buffer = new char[length];
+  _buffer = (char*)malloc(length);
   if (_buffer == nullptr)
   {
     throw "No data allocated";

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -75,8 +75,10 @@ File::File(const std::shared_ptr<Transmitter::FileDescription> &file_description
     throw "Unsupported FEC scheme";
   }
 
-  this->calculate_partitioning();
-  this->create_blocks();
+  encode();
+
+  calculate_partitioning();
+  create_blocks();
 }
 
 File::File(uint32_t toi,
@@ -269,6 +271,61 @@ auto File::mark_completed(const std::vector<EncodingSymbol>& symbols, bool succe
   }
 }
 
+auto File::encode() -> void
+{
+  if (!_been_encoded && !_meta.content_encoding.empty()) {
+    if (_meta.content_encoding == "gzip" || _meta.content_encoding=="deflate") {
+      auto decomp_buffer = _buffer;
+      bool own_decomp = _own_buffer;
+      std::shared_ptr<unsigned char> comp_buffer(new unsigned char[16384]);
+      z_stream zs = {
+        .next_in = reinterpret_cast<unsigned char*>(decomp_buffer),
+        .avail_in = static_cast<uint32_t>(_meta.content_length),
+        .next_out = comp_buffer.get(),
+        .avail_out = 16384
+      };
+      spdlog::debug("Compressing contents with {}", _meta.content_encoding);
+
+      if (deflateInit2(&zs, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
+        _buffer = nullptr;
+        auto zstate = deflate(&zs, Z_FINISH);
+        size_t last_out = 0;
+        while (zstate == Z_OK) {
+          spdlog::debug("Part compressed: {} bytes", 16384-zs.avail_out);
+          _buffer = reinterpret_cast<char*>(realloc(_buffer, zs.total_out));
+          memcpy(_buffer+last_out, comp_buffer.get(), 16384-zs.avail_out);
+          last_out = zs.total_out;
+          _own_buffer = true;
+          zs.avail_out = 16384;
+          zs.next_out = comp_buffer.get();
+          zstate = inflate(&zs, Z_FINISH);
+        }
+        if (zstate==Z_STREAM_END) {
+          if (last_out != zs.total_out) {
+            spdlog::debug("Finish compress, last block is {} bytes. Total {} bytes", 16384-zs.avail_out, zs.total_out);
+            _buffer = reinterpret_cast<char*>(realloc(_buffer, zs.total_out));
+            memcpy(_buffer+last_out, comp_buffer.get(), 16384-zs.avail_out);
+            _own_buffer = true;
+          }
+          _meta.fec_oti.transfer_length = zs.total_out;
+        } else {
+          spdlog::error("Error compressing file {}: {}", _meta.toi, zs.msg);
+          throw zs.msg;
+        }
+        deflateEnd(&zs);
+
+        if (own_decomp) free(decomp_buffer);
+      }
+    } else {
+      spdlog::error("Unknown Content-Encoding {}", _meta.content_encoding);
+      throw "Content-Encoding not known";
+    }
+
+    _been_encoded = true;
+    _been_decoded = false;
+  }
+}
+
 auto File::decode() -> void
 {
   if (!_been_decoded && !_meta.content_encoding.empty()) {
@@ -305,6 +362,11 @@ auto File::decode() -> void
           memcpy(_buffer+last_out, decomp_buffer.get(), 16384-zs.avail_out);
           _own_buffer = true;
         }
+        if (!_meta.content_length) {
+          _meta.content_length = zs.total_out;
+        } else if (_meta.content_length != zs.total_out) {
+          spdlog::error("Decompressed length does not match expected Content-Length ({} != {})", _meta.content_length, zs.total_out);
+        }
       } else {
         spdlog::error("Error decompressing file {}: {}", _meta.toi, zs.msg);
 	throw zs.msg;
@@ -317,6 +379,7 @@ auto File::decode() -> void
     }
 
     _been_decoded = true;
+    _been_encoded = false;
 
     // Check MD5
     if (!_meta.content_md5.empty()) {

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -94,7 +94,12 @@ namespace {
     if (pos != std::string::npos) {
       auto prefix = match_name.substr(0,pos);
       match_name.erase(0,pos+1);
-      match_ns = _prefix_to_ns_map.at(prefix);
+      auto it = _prefix_to_ns_map.find(prefix);
+      if (it != _prefix_to_ns_map.end()) {
+        match_ns = _prefix_to_ns_map.at(prefix);
+      } else {
+        match_ns = prefix;
+      }
     }
     return name == match_name && ns == match_ns;
   }
@@ -105,7 +110,13 @@ namespace {
     auto pos = elem_name.find_first_of(':');
     if (pos != std::string::npos) {
       auto elem_prefix = elem_name.substr(0,pos);
-      return _prefix_to_ns_map.at(elem_prefix);
+      auto it = _prefix_to_ns_map.find(elem_prefix);
+      if (it != _prefix_to_ns_map.end()) {
+        return _prefix_to_ns_map.at(elem_prefix);
+      } else {
+        static const std::string unknown("<Unknown>");
+        return unknown;
+      }
     }
     return _default_ns;
   }
@@ -120,8 +131,10 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_
 
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffer, size_t len) 
   : _instance_id( instance_id )
+  , _global_fec_oti()
 {
   static const std::string mbms2007_ns("urn:3GPP:metadata:2007:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
+  static const std::string mbms2012_ns("urn:3GPP:metadata:2012:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
   tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
   doc.Parse(buffer, len);
   auto fdt_instance = doc.RootElement();
@@ -149,22 +162,29 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
 
   spdlog::debug("Received new FDT with instance ID {}: {}", instance_id, buffer);
 
-  uint8_t def_fec_encoding_id = 0;
   auto val = root_ns.findAttribute(fdt_instance, "FEC-OTI-FEC-Encoding-ID", fdt_ns);
   if (val != nullptr) {
-    def_fec_encoding_id = strtoul(val->Value(), nullptr, 0);
+    _global_fec_oti.encoding_id = static_cast<FecScheme>(strtoul(val->Value(), nullptr, 0));
   }
 
-  uint32_t def_fec_max_source_block_length = 0;
+  val = root_ns.findAttribute(fdt_instance, "FEC-OTI-FEC-Instance-ID", fdt_ns);
+  if (val != nullptr) {
+    _global_fec_oti.instance_id = strtoul(val->Value(), nullptr, 0);
+  }
+
   val = root_ns.findAttribute(fdt_instance, "FEC-OTI-Maximum-Source-Block-Length", fdt_ns);
   if (val != nullptr) {
-    def_fec_max_source_block_length = strtoul(val->Value(), nullptr, 0);
+    _global_fec_oti.max_source_block_length = strtoul(val->Value(), nullptr, 0);
   }
 
-  uint32_t def_fec_encoding_symbol_length = 0;
   val = root_ns.findAttribute(fdt_instance, "FEC-OTI-Encoding-Symbol-Length", fdt_ns);
   if (val != nullptr) {
-    def_fec_encoding_symbol_length = strtoul(val->Value(), nullptr, 0);
+    _global_fec_oti.encoding_symbol_length = strtoul(val->Value(), nullptr, 0);
+  }
+
+  val = root_ns.findAttribute(fdt_instance, "FEC-OTI-Max-Number-of-Encoding-Symbols", fdt_ns);
+  if (val != nullptr) {
+    _global_fec_oti.max_number_of_encoding_symbols = strtoul(val->Value(), nullptr, 0);
   }
 
   for (auto file = root_ns.findChildElement(fdt_instance, "File", fdt_ns);
@@ -172,7 +192,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
 
     XMLNamespaces file_ns(file, root_ns);
 
-    // required attributes
+    // File required attributes
     auto toi_str = file_ns.findAttribute(file, "TOI", fdt_ns);
     if (toi_str == nullptr) {
       throw "Missing TOI attribute on File element";
@@ -184,6 +204,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
       throw "Missing Content-Location attribute on File element";
     }
 
+    // File optional attributes
     uint32_t content_length = 0;
     val = file_ns.findAttribute(file, "Content-Length", fdt_ns);
     if (val != nullptr) {
@@ -203,53 +224,103 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
       content_md5 = "";
     }
 
+    auto content_encoding = file_ns.findAttribute(file, "Content-Encoding", fdt_ns)->Value();
+    if (!content_encoding) {
+      content_encoding = "";
+    }
+
     auto content_type = file_ns.findAttribute(file, "Content-Type", fdt_ns)->Value();
     if (!content_type) {
       content_type = "";
     }
 
-    auto encoding_id = def_fec_encoding_id;
+    auto encoding_id = _global_fec_oti.encoding_id;
     val = file_ns.findAttribute(file, "FEC-OTI-FEC-Encoding-ID", fdt_ns);
     if (val != nullptr) {
-      encoding_id = strtoul(val->Value(), nullptr, 0);
+      encoding_id = static_cast<FecScheme>(strtoul(val->Value(), nullptr, 0));
     }
 
-    auto max_source_block_length = def_fec_max_source_block_length;
+    auto fec_instance_id = _global_fec_oti.instance_id;
+    val = file_ns.findAttribute(file, "FEC-OTI-FEC-Instance-ID", fdt_ns);
+    if (val != nullptr) {
+      fec_instance_id = strtoul(val->Value(), nullptr, 0);
+    }
+
+    auto max_source_block_length = _global_fec_oti.max_source_block_length;
     val = file_ns.findAttribute(file, "FEC-OTI-Maximum-Source-Block-Length", fdt_ns);
     if (val != nullptr) {
       max_source_block_length = strtoul(val->Value(), nullptr, 0);
     }
 
-    auto encoding_symbol_length = def_fec_encoding_symbol_length;
+    auto encoding_symbol_length = _global_fec_oti.encoding_symbol_length;
     val = file_ns.findAttribute(file, "FEC-OTI-Encoding-Symbol-Length", fdt_ns);
     if (val != nullptr) {
       encoding_symbol_length = strtoul(val->Value(), nullptr, 0);
     }
-    uint32_t expires = 0;
+
+    auto max_number_of_encoding_symbols = _global_fec_oti.max_number_of_encoding_symbols;
+    val = file_ns.findAttribute(file, "FEC-OTI-Max-Number-of-Encoding-Symbols", fdt_ns);
+    if (val != nullptr) {
+      max_number_of_encoding_symbols = strtoul(val->Value(), nullptr, 0);
+    }
+
+    auto mbms2012_file_etag = "";
+    val = file_ns.findAttribute(file, "File-ETag", mbms2012_ns);
+    if (val != nullptr) {
+      mbms2012_file_etag = val->Value();
+    }
+
+    // File optional elements
+
+    bool no_cache = false;
+    //bool max_stale = false;
+    std::optional<uint64_t> cache_expires = std::nullopt;
     auto cc = file_ns.findChildElement(file, "Cache-Control", mbms2007_ns);
     if (cc) {
       XMLNamespaces cc_ns(cc, file_ns);
+
+      // mbms2007:Cache-Control optional elements
+
+      auto no_cache_elem = cc_ns.findChildElement(cc, "no-cache", mbms2007_ns);
+      if (no_cache_elem) {
+        no_cache = true;
+      }
+
+      //auto max_stale_elem = cc_ns.findChildElement(cc, "max-stale", mbms2007_ns);
+      //if (max_stale_elem) {
+      //  max_stale = true;
+      //}
+
       auto expires_elem = cc_ns.findChildElement(cc, "Expires", mbms2007_ns);
       if (expires_elem) {
-        expires = strtoul(expires_elem->GetText(), nullptr, 0);
+        cache_expires = strtoul(expires_elem->GetText(), nullptr, 0);
       }
     }
 
     FecOti fec_oti{
-      (FecScheme)encoding_id,
-        transfer_length,
-        encoding_symbol_length,
-        max_source_block_length
+      .encoding_id = (FecScheme)encoding_id,
+      .instance_id = fec_instance_id,
+      .transfer_length = transfer_length,
+      .encoding_symbol_length = encoding_symbol_length,
+      .max_source_block_length = max_source_block_length,
+      .max_number_of_encoding_symbols = max_number_of_encoding_symbols
     };
 
     FileEntry fe{
       toi,
-        std::string(content_location->Value()),
-        content_length,
-        std::string(content_md5),
-        std::string(content_type),
-        expires,
-        fec_oti
+      std::string(content_location->Value()),
+      content_length,
+      std::string(content_md5),
+      std::string(content_type),
+      (cache_expires)?(cache_expires.value()):0,
+      fec_oti,
+      {
+        no_cache,
+        cache_expires
+      },
+      content_encoding,
+      mbms2012_file_etag,
+      transfer_length
     };
     _file_entries.push_back(fe);
   }
@@ -299,9 +370,11 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
   }
   root->SetAttribute("Expires", std::to_string(_expires).c_str());
   root->SetAttribute("FEC-OTI-FEC-Encoding-ID", (unsigned)_global_fec_oti.encoding_id);
+  if (_global_fec_oti.instance_id) root->SetAttribute("FEC-OTI-FEC-Instance-ID", (unsigned)_global_fec_oti.instance_id);
   root->SetAttribute("FEC-OTI-Maximum-Source-Block-Length", (unsigned)_global_fec_oti.max_source_block_length);
   root->SetAttribute("FEC-OTI-Encoding-Symbol-Length", (unsigned)_global_fec_oti.encoding_symbol_length);
   root->SetAttribute("xmlns:mbms2007", "urn:3GPP:metadata:2007:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
+  root->SetAttribute("xmlns:mbms2012", "urn:3GPP:metadata:2012:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
   doc.InsertEndChild(root);
 
   for (const auto& file : _file_entries) {
@@ -309,14 +382,34 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
     f->SetAttribute("TOI", file.toi);
     f->SetAttribute("Content-Location", file.content_location.c_str());
     f->SetAttribute("Content-Length", file.content_length);
-    f->SetAttribute("Transfer-Length", (unsigned)file.fec_oti.transfer_length);
-    f->SetAttribute("Content-MD5", file.content_md5.c_str());
-    f->SetAttribute("Content-Type", file.content_type.c_str());
-    auto cc = doc.NewElement("mbms2007:Cache-Control");
-    auto exp = doc.NewElement("mbms2007:Expires");
-    exp->SetText(std::to_string(file.expires).c_str());
-    cc->InsertEndChild(exp);
-    f->InsertEndChild(cc);
+    if (file.transfer_length) f->SetAttribute("Transfer-Length", file.transfer_length);
+    if (!file.content_md5.empty()) f->SetAttribute("Content-MD5", file.content_md5.c_str());
+    if (!file.content_encoding.empty()) f->SetAttribute("Content-Encoding", file.content_encoding.c_str());
+    if (!file.content_type.empty()) f->SetAttribute("Content-Type", file.content_type.c_str());
+    if (file.fec_oti.encoding_id != _global_fec_oti.encoding_id)
+      f->SetAttribute("FEC-OTI-FEC-Encoding-ID", (unsigned)file.fec_oti.encoding_id);
+    if (file.fec_oti.instance_id != 0 && file.fec_oti.instance_id != _global_fec_oti.instance_id)
+      f->SetAttribute("FEC-OTI-FEC-Instance-ID", (unsigned)file.fec_oti.instance_id);
+    if (file.fec_oti.max_source_block_length != 0 &&
+        file.fec_oti.max_source_block_length != _global_fec_oti.max_source_block_length)
+      f->SetAttribute("FEC-OTI-Maximum-Source-Block-Length", (unsigned)file.fec_oti.max_source_block_length);
+    if (file.fec_oti.encoding_symbol_length != 0 &&
+        file.fec_oti.encoding_symbol_length != _global_fec_oti.encoding_symbol_length)
+      f->SetAttribute("FEC-OTI-Encoding-Symbol-Length", (unsigned)file.fec_oti.encoding_symbol_length);
+    if (!file.etag.empty()) f->SetAttribute("mbms2012:File-ETag", file.etag.c_str());
+    if (file.cache_control.no_cache || file.cache_control.cache_expires) {
+      auto cc = doc.NewElement("mbms2007:Cache-Control");
+      if (file.cache_control.no_cache) {
+        auto noc = doc.NewElement("mbms2007:no-cache");
+        noc->SetText("true");
+        cc->InsertEndChild(noc);
+      } else {
+        auto exp = doc.NewElement("mbms2007:Expires");
+        exp->SetText(std::to_string(file.expires).c_str());
+        cc->InsertEndChild(exp);
+      }
+      f->InsertEndChild(cc);
+    }
     root->InsertEndChild(f);
   }
 

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -122,6 +122,15 @@ namespace {
   }
 }
 
+bool LibFlute::FileDeliveryTable::FileEntry::operator==(const LibFlute::FileDeliveryTable::FileEntry &other) const
+{
+  return toi == other.toi && content_length == other.content_length && expires == other.expires &&
+         cache_control.no_cache == other.cache_control.no_cache && fec_oti == other.fec_oti &&
+         cache_control.cache_expires == other.cache_control.cache_expires && content_location == other.content_location &&
+         content_md5 == other.content_md5 && content_type == other.content_type && content_encoding == other.content_encoding &&
+         etag == other.etag;
+}
+
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_oti, FdtNamespace fdt_namespace)
   : _instance_id( instance_id )
   , _global_fec_oti( fec_oti )
@@ -319,8 +328,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
         cache_expires
       },
       content_encoding,
-      mbms2012_file_etag,
-      transfer_length
+      mbms2012_file_etag
     };
     _file_entries.push_back(fe);
   }
@@ -382,7 +390,7 @@ auto LibFlute::FileDeliveryTable::to_string() const -> std::string {
     f->SetAttribute("TOI", file.toi);
     f->SetAttribute("Content-Location", file.content_location.c_str());
     f->SetAttribute("Content-Length", file.content_length);
-    if (file.transfer_length) f->SetAttribute("Transfer-Length", file.transfer_length);
+    if (file.fec_oti.transfer_length) f->SetAttribute("Transfer-Length", file.fec_oti.transfer_length);
     if (!file.content_md5.empty()) f->SetAttribute("Content-MD5", file.content_md5.c_str());
     if (!file.content_encoding.empty()) f->SetAttribute("Content-Encoding", file.content_encoding.c_str());
     if (!file.content_type.empty()) f->SetAttribute("Content-Type", file.content_type.c_str());

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -105,6 +105,8 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
             }
           }
 
+          file->decode();
+
           spdlog::debug("File with TOI {} completed", alc.toi());
           if (alc.toi() != 0 && _completion_cb) {
             _completion_cb(_files[alc.toi()]);

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -14,18 +14,39 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
+#include <errno.h>
+#include <fcntl.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
+#if HAVE_MMAP
+#include <sys/mman.h>
+#endif
+#include <unistd.h>
 
+// Suppress warnings about MD5 being deprecated in later versions of OpenSSL
+#define OPENSSL_SUPPRESS_DEPRECATED 1
+#include <openssl/md5.h>
+#include "base64.h"
+
+#include <zlib.h>
+
+#include <ctime>
 #include <cstdio>
 #include <chrono>
 #include <cstring>
+#include <exception>
 #include <iostream>
+#include <list>
 #include <string>
+#include <system_error>
 
 #include "spdlog/spdlog.h"
-#include "Transmitter.h"
+#include "File.h"
 #include "IpSec.h"
+
+#include "Transmitter.h"
+
+namespace LibFlute {
 
 static void create_udp_pkt( char *udp_buffer, const boost::asio::ip::udp::endpoint &endpoint, const char *data, size_t data_len,
                             const boost::asio::ip::address &local_address );
@@ -33,11 +54,428 @@ static void create_ip_hdr( char *ip_buffer, const boost::asio::ip::udp::endpoint
                            const boost::asio::ip::address &local_address );
 static uint16_t calculate_sum( uint16_t *buffer, size_t len );
 
-LibFlute::Transmitter::Transmitter ( const std::string& address, short port,
-                                     uint64_t tsi, unsigned short mtu, uint32_t rate_limit,
-                                     boost::asio::io_service& io_service,
-                                     const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint,
-                                     LibFlute::Transmitter::FdtNamespace fdt_namespace )
+/*****************************************************************************
+ * Transmitter::FileDescription class
+ *****************************************************************************/
+
+Transmitter::FileDescription::FileDescription ( const std::string &content_location, const std::string &filename )
+    : _tsi()
+    , _file_entry({ .toi=0, .content_location=content_location})
+    , _compression_type(Transmitter::FileDescription::COMPRESSION_NONE)
+    , _filename()
+    , _file_handle(-1)
+    , _data(nullptr)
+    , _data_length(0)
+    , _transfer_data(nullptr)
+    , _transfer_length(0)
+{
+  _attach_file(filename);
+  _calculate_file_entry();
+}
+
+Transmitter::FileDescription::FileDescription(const std::string &content_location, const std::vector<char> &data)
+    : _tsi()
+    , _file_entry({ .toi=0, .content_location=content_location})
+    , _compression_type(Transmitter::FileDescription::COMPRESSION_NONE)
+    , _filename()
+    , _file_handle(-1)
+    , _data(data.data())
+    , _data_length(data.size())
+    , _transfer_data(nullptr)
+    , _transfer_length(0)
+{
+  _calculate_file_entry();
+}
+
+Transmitter::FileDescription::FileDescription(const std::string &content_location, const char *data, size_t length)
+    : _tsi()
+    , _file_entry({ .toi=0, .content_location=content_location})
+    , _compression_type(Transmitter::FileDescription::COMPRESSION_NONE)
+    , _filename()
+    , _file_handle(-1)
+    , _data(data)
+    , _data_length(length)
+    , _transfer_data(nullptr)
+    , _transfer_length(0)
+{
+  _calculate_file_entry();
+}
+
+Transmitter::FileDescription::FileDescription(const std::string &content_location)
+    : _tsi()
+    , _file_entry({ .toi=0, .content_location=content_location})
+    , _compression_type(Transmitter::FileDescription::COMPRESSION_NONE)
+    , _filename()
+    , _file_handle(-1)
+    , _data(nullptr)
+    , _data_length(0)
+    , _transfer_data(nullptr)
+    , _transfer_length(0)
+{
+  _calculate_file_entry();
+}
+
+Transmitter::FileDescription::FileDescription(const Transmitter::FileDescription &other)
+    : _tsi(other._tsi)
+    , _file_entry(other._file_entry)
+    , _compression_type(other._compression_type)
+    , _filename(other._filename)
+    , _file_handle(-1)
+    , _data(other._data)
+    , _data_length(other._data_length)
+    , _transfer_data(nullptr)
+    , _transfer_length(0)
+{
+  if (!_filename.empty()) {
+    if (other._file_handle >= 0) {
+      _file_handle = dup(other._file_handle);
+    }
+#if HAVE_MMAP
+    // Map the file contents into memory
+    _data = reinterpret_cast<char*>(mmap(nullptr, _data_length, PROT_READ, MAP_SHARED, _file_handle, 0));
+#else
+    // copy the file contents into a new memory block
+    char *data = new char[_data_length];
+    _data = data;
+    memcpy(_data, other._data, _data_length);
+#endif
+  } 
+}
+
+Transmitter::FileDescription::FileDescription(Transmitter::FileDescription &&other)
+    : _tsi(std::move(other._tsi))
+    , _file_entry(other._file_entry)
+    , _compression_type(other._compression_type)
+    , _filename(std::move(other._filename))
+    , _file_handle(other._file_handle)
+    , _data(other._data)
+    , _data_length(other._data_length)
+    , _transfer_data(other._transfer_data)
+    , _transfer_length(other._transfer_length)
+{
+  other._data = nullptr;
+  other._data_length = 0;
+  other._transfer_data = nullptr;
+  other._transfer_length = 0;
+  other._file_handle = -1;
+}
+
+Transmitter::FileDescription::~FileDescription ()
+{
+  _free_file_data();
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::operator=(const Transmitter::FileDescription &other)
+{
+  _tsi = other._tsi;
+  _file_entry = other._file_entry;
+  _compression_type = other._compression_type;
+  _filename = other._filename;
+  _file_handle = -1;
+  _data = other._data;
+  _data_length = other._data_length;
+  _transfer_data = nullptr;
+  _transfer_length = 0;
+
+  if (!_filename.empty()) {
+    if (other._file_handle >= 0) {
+      _file_handle = dup(other._file_handle);
+    }
+#if HAVE_MMAP
+    // Map the file contents into memory
+    _data = reinterpret_cast<char*>(mmap(nullptr, _data_length, PROT_READ, MAP_SHARED, _file_handle, 0));
+#else
+    // copy the file contents into a new memory block
+    char *data = new char[_data_length];
+    _data = data;
+    memcpy(_data, other._data, _data_length);
+#endif
+  }
+
+  return *this;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::operator=(Transmitter::FileDescription &&other)
+{
+  _tsi = std::move(other._tsi);
+  _file_entry = other._file_entry;
+  _compression_type = other._compression_type;
+  _filename = std::move(other._filename);
+  _file_handle = other._file_handle;
+  other._file_handle = -1;
+
+  _data = other._data;
+  other._data = nullptr;
+  _data_length = other._data_length;
+  other._data_length = 0;
+
+  _transfer_data = other._transfer_data;
+  other._transfer_data = nullptr;
+  _transfer_length = other._transfer_length;
+  other._transfer_length = 0;
+
+  return *this;
+}
+
+bool Transmitter::FileDescription::operator==(const Transmitter::FileDescription &other) const
+{
+  if (_tsi != other._tsi) return false;
+  if (_compression_type != other._compression_type) return false;
+
+  // _file_entry
+  if (_file_entry.toi != other._file_entry.toi) return false;
+  if (_file_entry.expires != other._file_entry.expires) return false;
+  if (_file_entry.fec_oti != other._file_entry.fec_oti) return false;
+  if (_file_entry.content_location != other._file_entry.content_location) return false;
+  if (_file_entry.content_type != other._file_entry.content_type) return false;
+
+  //if (_filename != other._filename) return false;
+
+  if (_data_length != other._data_length) return false;
+
+  if (_data == other._data) return true;
+  return memcmp(_data, other._data, _data_length) == 0;
+}
+
+const char *Transmitter::FileDescription::data()
+{
+  _compress_data();
+  // If we have a compressed version cached, return that
+  if (_transfer_data) return _transfer_data;
+  // ...otherwise return the uncompressed data
+  return _data;
+}
+
+size_t Transmitter::FileDescription::data_length()
+{
+  _compress_data();
+  // If we have a compressed version cached, return the compressed length
+  if (_transfer_data) return _transfer_length;
+  // ...otherwise return the length of the uncompressed data
+  return _data_length;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
+								Transmitter::FileDescription::CompressionAlgorithm compression)
+{
+  if (compression != _compression_type) {
+    if (_transfer_data) {
+	delete[] _transfer_data;
+	_transfer_data = nullptr;
+        _transfer_length = 0;
+    }
+    _compression_type = compression;
+  }
+
+  return *this;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content(const std::string &filename)
+{
+  if (filename != _filename) {
+    _free_file_data();
+    _attach_file(filename);
+  }
+
+  return *this;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content(const char *data, size_t data_length)
+{
+  if (data != _data) {
+    _free_file_data();
+    _data = data;
+    _data_length = data_length;
+  }
+
+  return *this;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content(const std::vector<char> &data)
+{
+  return set_content(data.data(), data.size());
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content(const std::vector<unsigned char> &data)
+{
+  return set_content(reinterpret_cast<const char*>(data.data()), data.size());
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content_type(const std::string &content_type)
+{
+  _file_entry.content_type = content_type;
+  return *this;
+}
+
+static const Transmitter::FileDescription::date_time_type &_get_ntp_epoch()
+{
+  static bool is_set = false;
+  static Transmitter::FileDescription::date_time_type ntp_epoch;
+  if (!is_set) {
+    std::tm ntp_epoch_tm = {.tm_mday=1, .tm_mon=0, .tm_year=0};
+    ntp_epoch = std::chrono::system_clock::from_time_t(std::mktime(&ntp_epoch_tm));
+    is_set = true;
+  }
+  return ntp_epoch;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_expiry_time(
+								const Transmitter::FileDescription::date_time_type &expiry_time)
+{
+  auto diff = std::chrono::duration_cast<std::chrono::seconds>(expiry_time - _get_ntp_epoch());
+  _file_entry.expires = diff.count();
+  _file_entry.cache_control.cache_expires = _file_entry.expires;
+
+  return *this;
+}
+
+Transmitter::FileDescription::date_time_type Transmitter::FileDescription::get_expiry_time() const
+{
+  auto durn = std::chrono::duration_cast<date_time_type::duration>(std::chrono::seconds(_file_entry.expires));
+  return _get_ntp_epoch() + durn;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::merge_fec_oti(const FecOti &fec_oti)
+{
+  if (static_cast<unsigned>(_file_entry.fec_oti.encoding_id) == 0) {
+    _file_entry.fec_oti.encoding_id = fec_oti.encoding_id;
+  }
+  if (!_file_entry.fec_oti.instance_id) {
+    _file_entry.fec_oti.instance_id = fec_oti.instance_id;
+  }
+  //if (!_file_entry.fec_oti.transfer_length) {
+  //  _file_entry.fec_oti.transfer_length = fec_oti.transfer_length;
+  //}
+  if (!_file_entry.fec_oti.encoding_symbol_length) {
+    _file_entry.fec_oti.encoding_symbol_length = fec_oti.encoding_symbol_length;
+  }
+  if (!_file_entry.fec_oti.max_source_block_length) {
+    _file_entry.fec_oti.max_source_block_length = fec_oti.max_source_block_length;
+  }
+  if (!_file_entry.fec_oti.max_number_of_encoding_symbols) {
+    _file_entry.fec_oti.max_number_of_encoding_symbols = fec_oti.max_number_of_encoding_symbols;
+  }
+  return *this;
+}
+
+void Transmitter::FileDescription::_attach_file(const std::string &filename)
+{
+  _filename = filename;
+  _file_handle = open(_filename.c_str(), O_RDONLY);
+  if (_file_handle < 0) {
+    throw std::system_error(errno, std::generic_category(), "Could not open the file");
+  }
+  // Get the size
+  off_t pos = lseek(_file_handle, 0, SEEK_END);
+  if (pos < 0) {
+    throw std::system_error(errno, std::generic_category(), "Could not find the file length");
+  }
+  _data_length = static_cast<size_t>(pos);
+  lseek(_file_handle, 0, SEEK_SET);
+
+#if HAVE_MMAP
+  // Map the file contents into memory
+  _data = reinterpret_cast<char*>(mmap(nullptr, _data_length, PROT_READ, MAP_SHARED, _file_handle, 0));
+#else
+  // Load the file contents into memory
+  char *data = new char[_data_length];
+  _data = data;
+  read(_file_handle, data, _data_length);
+  close(_file_handle);
+  _file_handle = -1;
+#endif
+}
+
+void Transmitter::FileDescription::_free_file_data()
+{
+  if (!_filename.empty()) {
+#if HAVE_MMAP
+    if (_data) munmap(const_cast<char*>(_data), _data_length);
+    if (_file_handle >= 0) close(_file_handle);
+#else
+    delete[] const_cast<char*>(_data);
+#endif
+    _filename.clear();
+  }
+
+  if (_transfer_data) {
+    delete[] _transfer_data;
+  }
+}
+
+void Transmitter::FileDescription::_calculate_file_entry()
+{
+  // Content length
+  _file_entry.content_length = _data_length;
+
+  // MD5 checksum
+  if (_data && _data_length) {
+    unsigned char md5[MD5_DIGEST_LENGTH];
+    MD5(reinterpret_cast<const unsigned char*>(_data), _data_length, md5);
+    _file_entry.content_md5 = base64_encode(md5, sizeof(md5));
+  }
+}
+
+void Transmitter::FileDescription::_compress_data()
+{
+  // Do nothing if we already have a compressed version
+  if (_transfer_data) return;
+
+  // build compressed version or return the data pointer
+  if (_data) {
+    switch (_compression_type) {
+    case COMPRESSION_GZIP:
+      _gzip_data();
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+void Transmitter::FileDescription::_gzip_data()
+{
+  if (_transfer_data) delete[] _transfer_data;
+  _transfer_length = 0;
+  _transfer_data = nullptr;
+  
+  std::list<std::pair<unsigned char*, uint32_t> > buffers;
+  unsigned char *buffer = new unsigned char[8192];
+
+  z_stream strm = {.next_in = reinterpret_cast<unsigned char*>(const_cast<char*>(_data)),
+                   .avail_in = static_cast<uint32_t>(_data_length), .next_out = buffer, .avail_out = 8192};
+  if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
+    while (deflate(&strm, Z_FINISH) != Z_STREAM_END) {
+      buffers.push_back(std::make_pair(buffer, 8192 - strm.avail_out));
+      buffer = new unsigned char[8192];
+      strm.next_out = buffer;
+      strm.avail_out = 8192;
+    }
+    buffers.push_back(std::make_pair(buffer, 8192 - strm.avail_out));
+    deflateEnd(&strm);
+    _transfer_length = strm.total_out;
+    _transfer_data = new char[_transfer_length];
+    auto ptr = _transfer_data;
+    for (auto [buf, len] : buffers) {
+      memcpy(ptr, buf, len);
+      ptr += len;
+      delete[] buf;
+    }
+  }
+
+  _file_entry.transfer_length = _transfer_length;
+  _file_entry.content_encoding = "gzip";
+}
+
+/*****************************************************************************
+ * Transmitter class
+ *****************************************************************************/
+
+Transmitter::Transmitter ( const std::string& address, short port,
+                           uint64_t tsi, unsigned short mtu, uint32_t rate_limit,
+                           boost::asio::io_service& io_service,
+                           const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint,
+                           Transmitter::FdtNamespace fdt_namespace )
     : _endpoint(boost::asio::ip::address::from_string(address), port)
     , _socket(io_service, _endpoint.protocol())
     , _io_service(io_service)
@@ -70,7 +508,10 @@ LibFlute::Transmitter::Transmitter ( const std::string& address, short port,
   _socket.set_option(boost::asio::ip::multicast::enable_loopback(true));
   _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
 
-  _fec_oti = FecOti{FecScheme::CompactNoCode, 0, _max_payload, max_source_block_length};
+  _fec_oti = FecOti{
+    .encoding_id = FecScheme::CompactNoCode,
+    .encoding_symbol_length = _max_payload,
+    .max_source_block_length = max_source_block_length};
   _fdt = std::make_unique<FileDeliveryTable>(1, _fec_oti, fdt_namespace);
 
   _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
@@ -79,20 +520,20 @@ LibFlute::Transmitter::Transmitter ( const std::string& address, short port,
   send_next_packet();
 }
 
-LibFlute::Transmitter::~Transmitter() = default;
+Transmitter::~Transmitter() = default;
 
-auto LibFlute::Transmitter::enable_ipsec(uint32_t spi, const std::string& key) -> void
+auto Transmitter::enable_ipsec(uint32_t spi, const std::string& key) -> void
 {
-  LibFlute::IpSec::enable_esp(spi, _mcast_address, LibFlute::IpSec::Direction::Out, key);
+  IpSec::enable_esp(spi, _mcast_address, IpSec::Direction::Out, key);
 }
 
-auto LibFlute::Transmitter::handle_send_to(const boost::system::error_code& error) -> void
+auto Transmitter::handle_send_to(const boost::system::error_code& error) -> void
 {
   if (!error) {
   }
 }
 
-auto LibFlute::Transmitter::seconds_since_epoch() -> uint64_t
+auto Transmitter::seconds_since_epoch() -> uint64_t
 {
   return std::chrono::duration_cast<std::chrono::seconds>(
       std::chrono::system_clock::now().time_since_epoch()).count() +
@@ -100,7 +541,7 @@ auto LibFlute::Transmitter::seconds_since_epoch() -> uint64_t
                         and the NTP epoch (1 January 1900, 00:00:00 UTC) */
 }
 
-auto LibFlute::Transmitter::send_fdt() -> void {
+auto Transmitter::send_fdt() -> void {
   _fdt->set_expires(seconds_since_epoch() + _fdt_repeat_interval * 2);
   auto fdt = _fdt->to_string();
   auto file = std::make_shared<File>(
@@ -119,7 +560,7 @@ auto LibFlute::Transmitter::send_fdt() -> void {
   }
 }
 
-auto LibFlute::Transmitter::send(
+auto Transmitter::send(
     const std::string& content_location,
     const std::string& content_type,
     uint32_t expires,
@@ -145,14 +586,39 @@ auto LibFlute::Transmitter::send(
   return toi;
 }
 
-auto LibFlute::Transmitter::fdt_send_tick() -> void
+auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file_description) -> uint16_t
+{
+  if (file_description->has_tsi() && file_description->tsi() != _tsi) {
+    // Reset TOI if the file_description is being used on a new TSI
+    file_description->toi(0);
+  }
+
+  // Set the TSI and TOI for the FileDescription
+  file_description->tsi(_tsi);
+  if (file_description->toi() == 0) {
+    file_description->toi(_toi);
+    _toi++;
+    if (_toi == 0) _toi = 1; // clamp to >= 1 in case it wraps
+  }
+
+  // Copy in default FEC parameters if not already set
+  file_description->merge_fec_oti(_fec_oti);
+
+  auto file = std::make_shared<File>(file_description);
+  _fdt->add(file->meta());
+  send_fdt();
+  _files.insert({file_description->toi(), file});
+  return file_description->toi();
+}
+
+auto Transmitter::fdt_send_tick() -> void
 {
   send_fdt();
   _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
   _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this));
 }
 
-auto LibFlute::Transmitter::file_transmitted(uint32_t toi) -> void
+auto Transmitter::file_transmitted(uint32_t toi) -> void
 {
   if (toi != 0) {
     _files.erase(toi);
@@ -165,7 +631,7 @@ auto LibFlute::Transmitter::file_transmitted(uint32_t toi) -> void
   }
 }
 
-auto LibFlute::Transmitter::send_next_packet() -> void
+auto Transmitter::send_next_packet() -> void
 {
   uint32_t bytes_queued = 0;
 
@@ -298,3 +764,6 @@ static uint16_t calculate_sum(uint16_t *buffer, size_t len)
 
     return result;
 }
+
+} // End namespace LibFlute
+

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -83,6 +83,18 @@ Transmitter::FileDescription::FileDescription(const std::string &content_locatio
   _calculate_file_entry();
 }
 
+Transmitter::FileDescription::FileDescription(const std::string &content_location, const std::vector<unsigned char> &data)
+    : _tsi()
+    , _file_entry({ .toi=0, .content_location=content_location})
+    , _compression_type(Transmitter::FileDescription::COMPRESSION_NONE)
+    , _filename()
+    , _file_handle(-1)
+    , _data(reinterpret_cast<const char*>(data.data()))
+    , _data_length(data.size())
+{
+  _calculate_file_entry();
+}
+
 Transmitter::FileDescription::FileDescription(const std::string &content_location, const char *data, size_t length)
     : _tsi()
     , _file_entry({ .toi=0, .content_location=content_location})
@@ -238,6 +250,13 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
       break;
     }
   }
+
+  return *this;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_content_location(const std::string &location)
+{
+  _file_entry.content_location = location;
 
   return *this;
 }
@@ -519,6 +538,7 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
   if (file_description->has_tsi() && file_description->tsi() != _tsi) {
     // Reset TOI if the file_description is being used on a new TSI
     file_description->toi(0);
+    spdlog::debug("Reset TOI for FileDescription");
   }
 
   // Set the TSI and TOI for the FileDescription
@@ -527,6 +547,7 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
     file_description->toi(_toi);
     _toi++;
     if (_toi == 0) _toi = 1; // clamp to >= 1 in case it wraps
+    spdlog::debug("Assigned new TOI {}", file_description->toi());
   }
 
   // Copy in default FEC parameters if not already set

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -66,8 +66,6 @@ Transmitter::FileDescription::FileDescription ( const std::string &content_locat
     , _file_handle(-1)
     , _data(nullptr)
     , _data_length(0)
-    , _transfer_data(nullptr)
-    , _transfer_length(0)
 {
   _attach_file(filename);
   _calculate_file_entry();
@@ -81,8 +79,6 @@ Transmitter::FileDescription::FileDescription(const std::string &content_locatio
     , _file_handle(-1)
     , _data(data.data())
     , _data_length(data.size())
-    , _transfer_data(nullptr)
-    , _transfer_length(0)
 {
   _calculate_file_entry();
 }
@@ -95,8 +91,6 @@ Transmitter::FileDescription::FileDescription(const std::string &content_locatio
     , _file_handle(-1)
     , _data(data)
     , _data_length(length)
-    , _transfer_data(nullptr)
-    , _transfer_length(0)
 {
   _calculate_file_entry();
 }
@@ -109,8 +103,6 @@ Transmitter::FileDescription::FileDescription(const std::string &content_locatio
     , _file_handle(-1)
     , _data(nullptr)
     , _data_length(0)
-    , _transfer_data(nullptr)
-    , _transfer_length(0)
 {
   _calculate_file_entry();
 }
@@ -123,8 +115,6 @@ Transmitter::FileDescription::FileDescription(const Transmitter::FileDescription
     , _file_handle(-1)
     , _data(other._data)
     , _data_length(other._data_length)
-    , _transfer_data(nullptr)
-    , _transfer_length(0)
 {
   if (!_filename.empty()) {
     if (other._file_handle >= 0) {
@@ -150,13 +140,9 @@ Transmitter::FileDescription::FileDescription(Transmitter::FileDescription &&oth
     , _file_handle(other._file_handle)
     , _data(other._data)
     , _data_length(other._data_length)
-    , _transfer_data(other._transfer_data)
-    , _transfer_length(other._transfer_length)
 {
   other._data = nullptr;
   other._data_length = 0;
-  other._transfer_data = nullptr;
-  other._transfer_length = 0;
   other._file_handle = -1;
 }
 
@@ -174,8 +160,6 @@ Transmitter::FileDescription &Transmitter::FileDescription::operator=(const Tran
   _file_handle = -1;
   _data = other._data;
   _data_length = other._data_length;
-  _transfer_data = nullptr;
-  _transfer_length = 0;
 
   if (!_filename.empty()) {
     if (other._file_handle >= 0) {
@@ -209,11 +193,6 @@ Transmitter::FileDescription &Transmitter::FileDescription::operator=(Transmitte
   _data_length = other._data_length;
   other._data_length = 0;
 
-  _transfer_data = other._transfer_data;
-  other._transfer_data = nullptr;
-  _transfer_length = other._transfer_length;
-  other._transfer_length = 0;
-
   return *this;
 }
 
@@ -223,11 +202,7 @@ bool Transmitter::FileDescription::operator==(const Transmitter::FileDescription
   if (_compression_type != other._compression_type) return false;
 
   // _file_entry
-  if (_file_entry.toi != other._file_entry.toi) return false;
-  if (_file_entry.expires != other._file_entry.expires) return false;
-  if (_file_entry.fec_oti != other._file_entry.fec_oti) return false;
-  if (_file_entry.content_location != other._file_entry.content_location) return false;
-  if (_file_entry.content_type != other._file_entry.content_type) return false;
+  if (_file_entry != other._file_entry) return false;
 
   //if (_filename != other._filename) return false;
 
@@ -239,19 +214,11 @@ bool Transmitter::FileDescription::operator==(const Transmitter::FileDescription
 
 const char *Transmitter::FileDescription::data()
 {
-  _compress_data();
-  // If we have a compressed version cached, return that
-  if (_transfer_data) return _transfer_data;
-  // ...otherwise return the uncompressed data
   return _data;
 }
 
 size_t Transmitter::FileDescription::data_length()
 {
-  _compress_data();
-  // If we have a compressed version cached, return the compressed length
-  if (_transfer_data) return _transfer_length;
-  // ...otherwise return the length of the uncompressed data
   return _data_length;
 }
 
@@ -259,12 +226,17 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
 								Transmitter::FileDescription::CompressionAlgorithm compression)
 {
   if (compression != _compression_type) {
-    if (_transfer_data) {
-	delete[] _transfer_data;
-	_transfer_data = nullptr;
-        _transfer_length = 0;
-    }
     _compression_type = compression;
+    switch (_compression_type) {
+    case COMPRESSION_GZIP:
+      _file_entry.content_encoding = "gzip";
+      break;
+    case COMPRESSION_DEFLATE:
+      _file_entry.content_encoding = "deflate";
+      break;
+    default:
+      break;
+    }
   }
 
   return *this;
@@ -343,9 +315,9 @@ Transmitter::FileDescription &Transmitter::FileDescription::merge_fec_oti(const 
   if (!_file_entry.fec_oti.instance_id) {
     _file_entry.fec_oti.instance_id = fec_oti.instance_id;
   }
-  //if (!_file_entry.fec_oti.transfer_length) {
-  //  _file_entry.fec_oti.transfer_length = fec_oti.transfer_length;
-  //}
+  if (!_file_entry.fec_oti.transfer_length) {
+    _file_entry.fec_oti.transfer_length = fec_oti.transfer_length;
+  }
   if (!_file_entry.fec_oti.encoding_symbol_length) {
     _file_entry.fec_oti.encoding_symbol_length = fec_oti.encoding_symbol_length;
   }
@@ -397,10 +369,6 @@ void Transmitter::FileDescription::_free_file_data()
 #endif
     _filename.clear();
   }
-
-  if (_transfer_data) {
-    delete[] _transfer_data;
-  }
 }
 
 void Transmitter::FileDescription::_calculate_file_entry()
@@ -414,57 +382,6 @@ void Transmitter::FileDescription::_calculate_file_entry()
     MD5(reinterpret_cast<const unsigned char*>(_data), _data_length, md5);
     _file_entry.content_md5 = base64_encode(md5, sizeof(md5));
   }
-}
-
-void Transmitter::FileDescription::_compress_data()
-{
-  // Do nothing if we already have a compressed version
-  if (_transfer_data) return;
-
-  // build compressed version or return the data pointer
-  if (_data) {
-    switch (_compression_type) {
-    case COMPRESSION_GZIP:
-      _gzip_data();
-      break;
-    default:
-      break;
-    }
-  }
-}
-
-void Transmitter::FileDescription::_gzip_data()
-{
-  if (_transfer_data) delete[] _transfer_data;
-  _transfer_length = 0;
-  _transfer_data = nullptr;
-  
-  std::list<std::pair<unsigned char*, uint32_t> > buffers;
-  unsigned char *buffer = new unsigned char[8192];
-
-  z_stream strm = {.next_in = reinterpret_cast<unsigned char*>(const_cast<char*>(_data)),
-                   .avail_in = static_cast<uint32_t>(_data_length), .next_out = buffer, .avail_out = 8192};
-  if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
-    while (deflate(&strm, Z_FINISH) != Z_STREAM_END) {
-      buffers.push_back(std::make_pair(buffer, 8192 - strm.avail_out));
-      buffer = new unsigned char[8192];
-      strm.next_out = buffer;
-      strm.avail_out = 8192;
-    }
-    buffers.push_back(std::make_pair(buffer, 8192 - strm.avail_out));
-    deflateEnd(&strm);
-    _transfer_length = strm.total_out;
-    _transfer_data = new char[_transfer_length];
-    auto ptr = _transfer_data;
-    for (auto [buf, len] : buffers) {
-      memcpy(ptr, buf, len);
-      ptr += len;
-      delete[] buf;
-    }
-  }
-
-  _file_entry.transfer_length = _transfer_length;
-  _file_entry.content_encoding = "gzip";
 }
 
 /*****************************************************************************

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -26,7 +26,7 @@
 // Suppress warnings about MD5 being deprecated in later versions of OpenSSL
 #define OPENSSL_SUPPRESS_DEPRECATED 1
 #include <openssl/md5.h>
-#include "base64.h"
+#include "../utils/base64.h"
 
 #include <zlib.h>
 
@@ -305,6 +305,17 @@ Transmitter::FileDescription::date_time_type Transmitter::FileDescription::get_e
 {
   auto durn = std::chrono::duration_cast<date_time_type::duration>(std::chrono::seconds(_file_entry.expires));
   return _get_ntp_epoch() + durn;
+}
+
+Transmitter::FileDescription &Transmitter::FileDescription::set_etag(const std::string &etag)
+{
+  _file_entry.etag = etag;
+  return *this;
+}
+
+const std::string &Transmitter::FileDescription::get_etag() const
+{
+  return _file_entry.etag;
 }
 
 Transmitter::FileDescription &Transmitter::FileDescription::merge_fec_oti(const FecOti &fec_oti)

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -102,7 +102,7 @@ Transmitter::FileDescription::FileDescription(const std::string &content_locatio
     , _filename()
     , _file_handle(-1)
     , _data(data)
-    , _data_length(length)
+    , _data_length(data?length:0)
 {
   _calculate_file_entry();
 }
@@ -247,8 +247,12 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
       _file_entry.content_encoding = "deflate";
       break;
     default:
+      _file_entry.content_encoding.clear();
       break;
     }
+    /* change in compression will change transmitted data, reset the TOI */
+    _file_entry.toi = 0;
+    _calculate_file_entry();
   }
 
   return *this;
@@ -266,6 +270,9 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_content(const st
   if (filename != _filename) {
     _free_file_data();
     _attach_file(filename);
+    /* Assume a change of filename changes the contents too and zero the TOI */
+    _file_entry.toi = 0;
+    _calculate_file_entry();
   }
 
   return *this;
@@ -273,10 +280,36 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_content(const st
 
 Transmitter::FileDescription &Transmitter::FileDescription::set_content(const char *data, size_t data_length)
 {
-  if (data != _data) {
+  if (!data) data_length=0;
+  if (data != _data || _data_length != data_length) {
+    /* data area has changed in some way, do we need to reset the TOI? */
+    if (_data_length != data_length) {
+      /* data length has changed, reset the TOI */
+      _file_entry.toi = 0;
+    } else if (data) {
+      if (!_data) {
+	if (data_length) {
+          /* data being added, reset the TOI */
+          _file_entry.toi = 0;
+        }
+      } else if (data_length) {
+        /* had data before and have new data now, but are they the same? */
+        unsigned char md5[MD5_DIGEST_LENGTH];
+        MD5(reinterpret_cast<const unsigned char*>(data), data_length, md5);
+        if (_file_entry.content_md5 != base64_encode(md5, sizeof(md5))) {
+          /* data contents are different, reset TOI */
+          _file_entry.toi = 0;
+        }
+      }
+    } else if (_data) {
+      /* data being removed, reset the TOI */
+      _file_entry.toi = 0;
+    }
+       
     _free_file_data();
     _data = data;
     _data_length = data_length;
+    _calculate_file_entry();
   }
 
   return *this;
@@ -406,11 +439,16 @@ void Transmitter::FileDescription::_calculate_file_entry()
   // Content length
   _file_entry.content_length = _data_length;
 
+  // Initial transfer length assumes no encoding, this may be changed on transmission
+  _file_entry.fec_oti.transfer_length = _data_length;
+
   // MD5 checksum
   if (_data && _data_length) {
     unsigned char md5[MD5_DIGEST_LENGTH];
     MD5(reinterpret_cast<const unsigned char*>(_data), _data_length, md5);
     _file_entry.content_md5 = base64_encode(md5, sizeof(md5));
+  } else {
+    _file_entry.content_md5.clear();
   }
 }
 


### PR DESCRIPTION
This adds an extra `Transmitter::FileDescription` class to the library which can be used by applications to track sent files and resubmit them for sending under their original TOI. This will enable Carousel behaviours to be implemented by applications using rt-libflute. The `Transmitter::FileDescription` object can also be requested to flag the object contents for  *gzip* or *deflate* encoding before sending.

The `Transmitter` class has a new overload of the `send()` method which will take a `Transmitter::FileDescription` as the object to send. This allows the `Transmitter` to re-use the TOI when the same `Transmitter::FileDescription`  object is resubmitted via the `send()` method after the first `send()` of that object. This also allows the metadata and object contents to be updated between calls to `send()` in order to resent with new data/metadata.

The `Receiver` can also now detect content with a *Content-Encoding* of `gzip` or `deflate` and automatically decompress it before passing back to the application.

Closes #13 