### PR TITLE
Support Boost >= 1.87

### DIFF
--- a/include/Receiver.h
+++ b/include/Receiver.h
@@ -42,11 +42,11 @@ namespace LibFlute {
       *  @param address Multicast address
       *  @param port Target port 
       *  @param tsi TSI value of the session 
-      *  @param io_service Boost io_service to run the socket operations in (must be provided by the caller)
+      *  @param io_context Boost io_context to run the socket operations in (must be provided by the caller)
       */
       Receiver( const std::string& iface, const std::string& address, 
           short port, uint64_t tsi,
-          boost::asio::io_service& io_service);
+          boost::asio::io_context& io_context);
 
      /**
       *  Default destructor.

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -369,14 +369,14 @@ namespace LibFlute {
       *  @param tsi TSI value for the session 
       *  @param mtu Path MTU to size FLUTE packets for 
       *  @param rate_limit Transmit rate limit (in kbps)
-      *  @param io_service Boost io_service to run the socket operations in (must be provided by the caller)
+      *  @param io_context Boost io_context to run the socket operations in (must be provided by the caller)
       *  @param tunnel_endpoint Tunnelling endpoint address (default: no tunnelling)
       *  @param fdt_namespace Which XML namespace to use for the FDT (default: none)
       */
       Transmitter( const std::string& address, 
           short port, uint64_t tsi, unsigned short mtu,
           uint32_t rate_limit,
-          boost::asio::io_service& io_service,
+          boost::asio::io_context& io_context,
           const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint = std::nullopt,
           FdtNamespace fdt_namespace = FileDeliveryTable::FDT_NS_NONE);
 
@@ -455,7 +455,7 @@ namespace LibFlute {
       void handle_send_to(const boost::system::error_code& error);
       boost::asio::ip::udp::endpoint _endpoint;
       boost::asio::ip::udp::socket _socket;
-      boost::asio::io_service& _io_service;
+      boost::asio::io_context& _io_context;
       boost::asio::deadline_timer _send_timer;
       boost::asio::deadline_timer _fdt_timer;
 

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -23,13 +23,13 @@
 
 LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& address,
     short port, uint64_t tsi, 
-    boost::asio::io_service& io_service)
-    : _socket(io_service)
+    boost::asio::io_context& io_context)
+    : _socket(io_context)
     , _tsi(tsi)
     , _mcast_address(address)
 {
     boost::asio::ip::udp::endpoint listen_endpoint(
-        boost::asio::ip::address::from_string(iface), port);
+        boost::asio::ip::make_address(iface), port);
     _socket.open(listen_endpoint.protocol());
     _socket.set_option(boost::asio::ip::multicast::enable_loopback(true));
     _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
@@ -39,7 +39,7 @@ LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& addr
     // Join the multicast group.
     _socket.set_option(
         boost::asio::ip::multicast::join_group(
-          boost::asio::ip::address::from_string(address)));
+          boost::asio::ip::make_address(address)));
 
     _socket.async_receive_from(
         boost::asio::buffer(_data, max_length), _sender_endpoint,

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -458,14 +458,14 @@ void Transmitter::FileDescription::_calculate_file_entry()
 
 Transmitter::Transmitter ( const std::string& address, short port,
                            uint64_t tsi, unsigned short mtu, uint32_t rate_limit,
-                           boost::asio::io_service& io_service,
+                           boost::asio::io_context& io_context,
                            const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint,
                            Transmitter::FdtNamespace fdt_namespace )
-    : _endpoint(boost::asio::ip::address::from_string(address), port)
-    , _socket(io_service, _endpoint.protocol())
-    , _io_service(io_service)
-    , _send_timer(io_service)
-    , _fdt_timer(io_service)
+    : _endpoint(boost::asio::ip::make_address(address), port)
+    , _socket(io_context, _endpoint.protocol())
+    , _io_context(io_context)
+    , _send_timer(io_context)
+    , _fdt_timer(io_context)
     , _tsi(tsi)
     , _mtu(mtu)
     , _files()
@@ -484,7 +484,7 @@ Transmitter::Transmitter ( const std::string& address, short port,
     // Remove extra overhead for UDP tunnelling, if set
     _max_payload -= 20 - // IPv4 header
                     8; // UDP header
-    boost::asio::ip::udp::socket local_socket(io_service, _tunnel_endpoint.value().protocol());
+    boost::asio::ip::udp::socket local_socket(io_context, _tunnel_endpoint.value().protocol());
     local_socket.connect(_tunnel_endpoint.value());
     _tunnel_local_address = local_socket.local_endpoint().address();
   }
@@ -678,7 +678,7 @@ auto Transmitter::send_next_packet() -> void
     _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
   } else {
     if (_rate_limit == 0) {
-      _io_service.post(boost::bind(&Transmitter::send_next_packet, this));
+      boost::asio::post(_io_context, boost::bind(&Transmitter::send_next_packet, this));
     } else {
       auto send_duration = ((bytes_queued * 8.0) / (double)_rate_limit/1000.0) * 1000.0 * 1000.0;
       spdlog::trace("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us",
@@ -701,8 +701,8 @@ static void create_udp_pkt(char *udp_buffer, const boost::asio::ip::udp::endpoin
   } *pseudo_hdr = reinterpret_cast<struct udp_pseudo_hdr*>(udp_buffer - sizeof(*pseudo_hdr));
   struct udphdr *udp_hdr = reinterpret_cast<struct udphdr*>(udp_buffer);
 
-  pseudo_hdr->source = htonl(local_address.to_v4().to_ulong());
-  pseudo_hdr->dest = htonl(endpoint.address().to_v4().to_ulong());
+  pseudo_hdr->source = htonl(local_address.to_v4().to_uint());
+  pseudo_hdr->dest = htonl(endpoint.address().to_v4().to_uint());
   pseudo_hdr->reserved = 0;
   pseudo_hdr->protocol = endpoint.protocol().protocol();
   pseudo_hdr->length = htons(data_len + 8);
@@ -729,8 +729,8 @@ static void create_ip_hdr(char *ip_buffer, const boost::asio::ip::udp::endpoint 
   ip_hdr->ttl = 63; // TTL 63 hops
   ip_hdr->protocol = endpoint.protocol().protocol();
   ip_hdr->check = 0;
-  ip_hdr->saddr = htonl(local_address.to_v4().to_ulong());
-  ip_hdr->daddr = htonl(endpoint.address().to_v4().to_ulong());
+  ip_hdr->saddr = htonl(local_address.to_v4().to_uint());
+  ip_hdr->daddr = htonl(endpoint.address().to_v4().to_uint());
 
   ip_hdr->check = calculate_sum(reinterpret_cast<uint16_t*>(ip_hdr), 20);
 }


### PR DESCRIPTION
Boost.Asio removed several deprecated functions in version 1.87. This commit updates the codebase to be compatible with the latest Boost API:

- Replace boost::asio::io_service with boost::asio::io_context
- Replace boost::asio::ip::address::from_string with boost::asio::ip::make_address
- Replace boost::asio::ip::address_v4::to_ulong with boost::asio::ip::address_v4::to_uint