### PR TITLE
EncodingSymbol: fix buffer pointer handling and add warning on overflow

### DIFF
--- a/src/EncodingSymbol.cpp
+++ b/src/EncodingSymbol.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <arpa/inet.h>
 #include "EncodingSymbol.h"
+#include "spdlog/spdlog.h"
 
 auto LibFlute::EncodingSymbol::from_payload(char* encoded_data, size_t data_len, const FecOti& fec_oti, ContentEncoding encoding) -> std::vector<EncodingSymbol> 
 {
@@ -72,8 +73,11 @@ auto LibFlute::EncodingSymbol::to_payload(const std::vector<EncodingSymbol>& sym
     if (symbol.len() <= data_len) {
       auto symbol_len = symbol.encode_to(ptr, data_len);
       data_len -= symbol_len;
-      encoded_data += symbol_len;
       len += symbol_len;
+      ptr += symbol_len;
+    } else {
+      spdlog::warn("Not enough space in payload buffer for encoding symbol");
+      break;
     }
   }
   return len;


### PR DESCRIPTION
Fixes an issue where the wrong buffer pointer (encoded_data instead of ptr) was incremented after copying a symbol.

Since normally only one symbol is present in the vector, this bug did not cause any noticeable issue so far.

Added a warn log when the payload buffer does not have enough space to encode a symbol. This prevents errors ignored silently and will make debugging easier.