### PR TITLE
Fix examples by replacing boost::asio::io_service with io_context

### DIFF
--- a/examples/flute-receiver.cpp
+++ b/examples/flute-receiver.cpp
@@ -142,8 +142,8 @@ auto main(int argc, char **argv) -> int {
   spdlog::info("FLUTE receiver demo starting up");
 
   try {
-    // Create a Boost io_service
-    boost::asio::io_service io;
+    // Create a Boost io_context
+    boost::asio::io_context io;
 
     // Create the receiver
     LibFlute::Receiver receiver(

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -221,7 +221,7 @@ static void send_with_new_api(struct ft_arguments &arguments)
           file_entry.content_location, file_entry.content_length, file_entry.fec_oti.transfer_length, toi);
   }
 
-  // Start the io_service, and thus sending data
+  // Start the io_context, and thus sending data
   io.run();
 }
 
@@ -290,7 +290,7 @@ static void send_with_old_api(struct ft_arguments &arguments)
           file.location, file.len, file.toi);
   }
 
-  // Start the io_service, and thus sending data
+  // Start the io_context, and thus sending data
   io.run();
 }
 

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -181,8 +181,8 @@ static void send_with_new_api(struct ft_arguments &arguments)
     files.emplace_back(fd);
   }
 
-  // Create a Boost io_service
-  boost::asio::io_service io;
+  // Create a Boost io_context
+  boost::asio::io_context io;
 
   // Construct the transmitter class
   LibFlute::Transmitter transmitter(
@@ -249,8 +249,8 @@ static void send_with_old_api(struct ft_arguments &arguments)
     files.push_back(FsFile{ location, buffer, (size_t)size});
   }
 
-  // Create a Boost io_service
-  boost::asio::io_service io;
+  // Create a Boost io_context
+  boost::asio::io_context io;
 
   // Construct the transmitter class
   LibFlute::Transmitter transmitter(


### PR DESCRIPTION
 This fix follows PR #20 Support Boost >= 1.87