### PR TITLE
Prevent receiver from stopping on unknown TSI

### DIFF
--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -64,11 +64,8 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
     try {
       auto alc = LibFlute::AlcPacket(_data, bytes_recvd);
 
-      if (alc.tsi() != _tsi) {
-        spdlog::warn("Discarding packet for unknown TSI {}", alc.tsi());
-        return;
-      }
-
+      if (alc.tsi() == _tsi) {
+       
       const std::lock_guard<std::mutex> lock(_files_mutex);
 
       if (alc.toi() == 0 && (!_fdt || _fdt->instance_id() != alc.fdt_instance_id())) {
@@ -131,6 +128,9 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
       } else {
         spdlog::trace("Discarding packet for unknown or already completed file with TOI {}", alc.toi());
       }
+    } else {
+       spdlog::warn("Discarding packet for unknown TSI {}", alc.tsi());
+    }
     } catch (const std::exception &ex) {
       spdlog::warn("Failed to decode ALC/FLUTE packet: {}", ex.what());
     }

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -66,71 +66,71 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
 
       if (alc.tsi() == _tsi) {
        
-      const std::lock_guard<std::mutex> lock(_files_mutex);
+        const std::lock_guard<std::mutex> lock(_files_mutex);
 
-      if (alc.toi() == 0 && (!_fdt || _fdt->instance_id() != alc.fdt_instance_id())) {
-        if (_files.find(alc.toi()) == _files.end()) {
-          FileDeliveryTable::FileEntry fe{0, "", static_cast<uint32_t>(alc.fec_oti().transfer_length), "", "", 0, alc.fec_oti()};
-          _files.emplace(alc.toi(), std::make_shared<LibFlute::File>(fe));
-        }
-      }
-
-      if (_files.find(alc.toi()) != _files.end() && !_files[alc.toi()]->complete()) {
-        auto encoding_symbols = LibFlute::EncodingSymbol::from_payload(
-            _data + alc.header_length(), 
-            bytes_recvd - alc.header_length(),
-            _files[alc.toi()]->fec_oti(),
-            alc.content_encoding());
-
-        for (const auto& symbol : encoding_symbols) {
-          spdlog::debug("received TOI {} SBN {} ID {}", alc.toi(), symbol.source_block_number(), symbol.id() );
-          _files[alc.toi()]->put_symbol(symbol);
+        if (alc.toi() == 0 && (!_fdt || _fdt->instance_id() != alc.fdt_instance_id())) {
+          if (_files.find(alc.toi()) == _files.end()) {
+            FileDeliveryTable::FileEntry fe{0, "", static_cast<uint32_t>(alc.fec_oti().transfer_length), "", "", 0, alc.fec_oti()};
+            _files.emplace(alc.toi(), std::make_shared<LibFlute::File>(fe));
+          }
         }
 
-        auto file = _files[alc.toi()].get();
-        if (_files[alc.toi()]->complete()) {
-          for (auto it = _files.cbegin(); it != _files.cend();)
-          {
-            if (it->second.get() != file && it->second->meta().content_location == file->meta().content_location)
-            {
-              spdlog::debug("Replacing file with TOI {}", it->first);
-              it = _files.erase(it);
-            }
-            else
-            {
-              ++it;
-            }
+        if (_files.find(alc.toi()) != _files.end() && !_files[alc.toi()]->complete()) {
+          auto encoding_symbols = LibFlute::EncodingSymbol::from_payload(
+              _data + alc.header_length(), 
+              bytes_recvd - alc.header_length(),
+              _files[alc.toi()]->fec_oti(),
+              alc.content_encoding());
+
+          for (const auto& symbol : encoding_symbols) {
+            spdlog::debug("received TOI {} SBN {} ID {}", alc.toi(), symbol.source_block_number(), symbol.id() );
+            _files[alc.toi()]->put_symbol(symbol);
           }
 
-          file->decode();
+          auto file = _files[alc.toi()].get();
+          if (_files[alc.toi()]->complete()) {
+            for (auto it = _files.cbegin(); it != _files.cend();)
+            {
+              if (it->second.get() != file && it->second->meta().content_location == file->meta().content_location)
+              {
+                spdlog::debug("Replacing file with TOI {}", it->first);
+                it = _files.erase(it);
+              }
+              else
+              {
+                ++it;
+              }
+            }
 
-          spdlog::debug("File with TOI {} completed", alc.toi());
-          if (alc.toi() != 0 && _completion_cb) {
-            _completion_cb(_files[alc.toi()]);
-            _files.erase(alc.toi());
-          }
+            file->decode();
 
-          if (alc.toi() == 0) { // parse complete FDT
-            _fdt = std::make_unique<LibFlute::FileDeliveryTable>(
-                alc.fdt_instance_id(), _files[alc.toi()]->buffer(), _files[alc.toi()]->length());
+            spdlog::debug("File with TOI {} completed", alc.toi());
+            if (alc.toi() != 0 && _completion_cb) {
+              _completion_cb(_files[alc.toi()]);
+              _files.erase(alc.toi());
+            }
 
-            _files.erase(alc.toi());
-            for (const auto& file_entry : _fdt->file_entries()) {
-              // automatically receive all files in the FDT
-              if (_files.find(file_entry.toi) == _files.end()) {
-                spdlog::debug("Starting reception for file with TOI {}: {} ({})", file_entry.toi,
-                    file_entry.content_location, file_entry.content_type);
-                _files.emplace(file_entry.toi, std::make_shared<LibFlute::File>(file_entry));
+            if (alc.toi() == 0) { // parse complete FDT
+              _fdt = std::make_unique<LibFlute::FileDeliveryTable>(
+                  alc.fdt_instance_id(), _files[alc.toi()]->buffer(), _files[alc.toi()]->length());
+
+              _files.erase(alc.toi());
+              for (const auto& file_entry : _fdt->file_entries()) {
+                // automatically receive all files in the FDT
+                if (_files.find(file_entry.toi) == _files.end()) {
+                  spdlog::debug("Starting reception for file with TOI {}: {} ({})", file_entry.toi,
+                      file_entry.content_location, file_entry.content_type);
+                  _files.emplace(file_entry.toi, std::make_shared<LibFlute::File>(file_entry));
+                }
               }
             }
           }
+        } else {
+          spdlog::trace("Discarding packet for unknown or already completed file with TOI {}", alc.toi());
         }
       } else {
-        spdlog::trace("Discarding packet for unknown or already completed file with TOI {}", alc.toi());
+        spdlog::warn("Discarding packet for unknown TSI {}", alc.tsi());
       }
-    } else {
-       spdlog::warn("Discarding packet for unknown TSI {}", alc.tsi());
-    }
     } catch (const std::exception &ex) {
       spdlog::warn("Failed to decode ALC/FLUTE packet: {}", ex.what());
     }


### PR DESCRIPTION
Previously the FLUTE receiver stopped if it encountered a packet with a TSI different from the expected one.

This fix allows the reception of a FLUTE session even when multiple sessions are multiplexed in the same UDP/IP multicast stream.