### PR TITLE
Add new Transmitter methods to change MBR, UDP Tunnel and Destination address

### DIFF
--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -362,7 +362,7 @@ namespace LibFlute {
       typedef std::function<void(uint32_t)> completion_callback_t;
 
      /**
-      *  Default constructor.
+      *  Constructor.
       *
       *  @param address Target multicast address
       *  @param port Target port
@@ -384,6 +384,121 @@ namespace LibFlute {
       *  Default destructor.
       */
       virtual ~Transmitter();
+
+     /**
+      * Get UDP Tunnel Address
+      *
+      * @return The optional UDP Tunnel Address for the Transmitter to use.
+      */
+      const std::optional<boost::asio::ip::udp::endpoint> &udp_tunnel_address() const { return _tunnel_endpoint; };
+
+     /**
+      * Set UDP Tunnel Address
+      *
+      * Sets the UDP tunnel endpoint to be a copy of @p new_tunnel_endpoint.
+      *
+      * @param new_tunnel_endpoint The new UDP tunnel endpoint to set.
+      * @return This Transmitter object.
+      */
+      Transmitter &udp_tunnel_address(const boost::asio::ip::udp::endpoint &new_tunnel_endpoint);
+
+     /**
+      * Set UDP Tunnel Address
+      *
+      * Sets the UDP tunnel endpoint to be @p new_tunnel_endpoint. This moves the value from @p new_tunnel_endpoint.
+      *
+      * @param new_tunnel_endpoint The new UDP tunnel endpoint to set.
+      * @return This Transmitter object.
+      */
+      Transmitter &udp_tunnel_address(boost::asio::ip::udp::endpoint &&new_tunnel_endpoint);
+
+     /**
+      * Set UDP Tunnel Address
+      *
+      * Sets the UDP tunnel endpoint to be a copy of the optional @p new_tunnel_endpoint.
+      *
+      * @param new_tunnel_endpoint The optional UDP tunnel endpoint to set.
+      * @return This Transmitter object.
+      */
+      Transmitter &udp_tunnel_address(const std::optional<boost::asio::ip::udp::endpoint> &new_tunnel_endpoint);
+
+     /**
+      * Set UDP Tunnel Address
+      *
+      * Sets the UDP tunnel endpoint to be the optional @p new_tunnel_endpoint. This moves the value from @p new_tunnel_endpoint.
+      *
+      * @param new_tunnel_endpoint The optional UDP tunnel endpoint to set.
+      * @return This Transmitter object.
+      */
+      Transmitter &udp_tunnel_address(std::optional<boost::asio::ip::udp::endpoint> &&new_tunnel_endpoint);
+
+     /**
+      * Unset UDP Tunnel Address
+      *
+      * Removes the UDP tunnel endpoint. If the stream is active then it will switch back to multicast transmission.
+      *
+      * @return This Transmitter object.
+      */
+      Transmitter &udp_tunnel_address(const std::nullopt_t&);
+
+     /**
+      * Get Maximum Bit Rate
+      *
+      * Returns the maximum bit rate (MBR) value that the Transmitter is using. A 0 MBR means no limit.
+      *
+      * @return The maximum bit rate.
+      */
+      uint32_t rate_limit() const { return _rate_limit; };
+
+     /**
+      * Set Maximum Bit Rate
+      *
+      * Sets the MBR for transmission. A value of 0 indicates no rate limit.
+      *
+      * @param limit The new MBR to set.
+      * @return This Transmitter object.
+      */
+      Transmitter &rate_limit(uint32_t limit) { _rate_limit = limit; return *this; };
+
+     /**
+      * Get UDP Address for FLUTE session
+      *
+      * Gets the destination address for the FLUTE session packets. If the UDP tunnel address is set then the packets will be
+      * tunnelled to the UDP tunnel address, otherwise packets are sent directly to the destination address.
+      *
+      * @return The current destination address.
+      */
+      const boost::asio::ip::udp::endpoint &endpoint() const { return _endpoint; };
+
+     /**
+      * Set UDP Address for FLUTE session
+      *
+      * Sets the destination address for FLUTE session packets. If the UDP Tunnel Address is not set then FLUTE packets will be
+      * sent directly to this UDP endpoint. When a UDP Tunnel Address is set then FLUTE packets with this destination will be
+      * tunnelled to the UDP Tunnel Address.
+      *
+      * @param address The IP address or hostname to set as the FLUTE packet destination address.
+      * @param port The UDP port number to set as the FLUTE packet destination UDP port.
+      *
+      * @return This Transmitter object.
+      */
+      Transmitter &endpoint(const std::string &address, uint32_t port);
+
+     /**@{*/
+     /**
+      * Set UDP Address for FLUTE session
+      *
+      * Sets the destination address for FLUTE session packets. If the UDP Tunnel Address is not set then FLUTE packets will be
+      * sent directly to this UDP endpoint. When a UDP Tunnel Address is set then FLUTE packets with this destination will be
+      * tunnelled to the UDP Tunnel Address.
+      *
+      * @param destination The UDP endpoint to set as the FLUTE packet destination address and port.
+      *
+      * @return This Transmitter object.
+      */
+      Transmitter &endpoint(const boost::asio::ip::udp::endpoint &destination);
+      Transmitter &endpoint(boost::asio::ip::udp::endpoint &&destination);
+     /**@}*/
 
      /**
       *  Enable IPSEC ESP encryption of FLUTE payloads.

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -482,7 +482,7 @@ Transmitter::Transmitter ( const std::string& address, short port,
      4;  // SBN and ESI for compact no-code FEC
   if (_tunnel_endpoint.has_value()) {
     // Remove extra overhead for UDP tunnelling, if set
-    _max_payload -= 20 - // IPv4 header
+    _max_payload -= 20 + // IPv4 header
                     8; // UDP header
     boost::asio::ip::udp::socket local_socket(_io_context, _tunnel_endpoint.value().protocol());
     local_socket.connect(_tunnel_endpoint.value());
@@ -506,6 +506,68 @@ Transmitter::Transmitter ( const std::string& address, short port,
 }
 
 Transmitter::~Transmitter() = default;
+
+auto Transmitter::udp_tunnel_address(const boost::asio::ip::udp::endpoint &new_tunnel_endpoint) -> Transmitter&
+{
+  return udp_tunnel_address(std::optional<boost::asio::ip::udp::endpoint>(new_tunnel_endpoint));
+}
+
+auto Transmitter::udp_tunnel_address(boost::asio::ip::udp::endpoint &&new_tunnel_endpoint) -> Transmitter&
+{
+  return udp_tunnel_address(std::optional<boost::asio::ip::udp::endpoint>(std::move(new_tunnel_endpoint)));
+}
+
+auto Transmitter::udp_tunnel_address(const std::optional<boost::asio::ip::udp::endpoint> &new_tunnel_endpoint) -> Transmitter&
+{
+  return udp_tunnel_address(std::move(std::optional<boost::asio::ip::udp::endpoint>(new_tunnel_endpoint)));
+}
+
+auto Transmitter::udp_tunnel_address(std::optional<boost::asio::ip::udp::endpoint> &&new_tunnel_endpoint) -> Transmitter&
+{
+  if (!!_tunnel_endpoint == !!new_tunnel_endpoint) {
+    /* change existing tunnel */
+    if (_tunnel_endpoint) _tunnel_endpoint = new_tunnel_endpoint;
+  } else if (_tunnel_endpoint) {
+    /* removing tunnel */
+    _max_payload += 20 + // IPv4 header
+                    8; // UDP header
+    _tunnel_endpoint = std::nullopt;
+  } else {
+    /* new tunnel */
+    _tunnel_endpoint = std::move(new_tunnel_endpoint);
+    _max_payload -= 20 + // IPv4 header
+                    8; // UDP header
+  }
+
+  if (_tunnel_endpoint) {
+    boost::asio::ip::udp::socket local_socket(_io_context, _tunnel_endpoint.value().protocol());
+    local_socket.connect(_tunnel_endpoint.value());
+    _tunnel_local_address = local_socket.local_endpoint().address();
+  }
+  return *this;
+}
+
+auto Transmitter::udp_tunnel_address(const std::nullopt_t&) -> Transmitter&
+{
+  return udp_tunnel_address(std::optional<boost::asio::ip::udp::endpoint>(std::nullopt));
+}
+
+auto Transmitter::endpoint(const std::string &address, uint32_t port) -> Transmitter&
+{
+  return endpoint(boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(address), port));
+}
+
+auto Transmitter::endpoint(const boost::asio::ip::udp::endpoint &destination) -> Transmitter&
+{
+  _endpoint = destination;
+  return *this;
+}
+
+auto Transmitter::endpoint(boost::asio::ip::udp::endpoint &&destination) -> Transmitter&
+{
+  _endpoint = std::move(destination);
+  return *this;
+}
 
 auto Transmitter::enable_ipsec(uint32_t spi, const std::string& key) -> void
 {


### PR DESCRIPTION
Closes #28 

This adds getter and setter methods for 3 attributes of the `LibFLute::Transmitter` object, rate_limit (MBR), udp_tunnel_address and endpoint (FLUTE packet destination address).

This allows an application using this library to modify some aspects of the FLUTE stream, at runtime, without having to create a new  `LibFLute::Transmitter` object. This provides continuity for TOIs and FDT instance versions in a FLUTE session.

This also fixes a bug with the tunnelled packet size calculation.