### PR TITLE
Fix Empty FDT and add session activation/deactivation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project (libflute VERSION 0.11.0)
+project (libflute VERSION 0.12.0)
 
 include(CheckCXXSymbolExists)
 

--- a/examples/flute-transmitter.cpp
+++ b/examples/flute-transmitter.cpp
@@ -201,7 +201,7 @@ static void send_with_new_api(struct ft_arguments &arguments)
 
   // Register a completion callback
   transmitter.register_completion_callback(
-        [&files, &arguments, &transmitter](uint32_t toi) {
+        [&files, &arguments, &transmitter](uint32_t toi) -> void {
           for (auto& f : files) {
             if (f.file->toi() == toi) {
               spdlog::info("{} (TOI {}) has been transmitted", f.file->file_entry().content_location, f.file->toi());
@@ -269,7 +269,7 @@ static void send_with_old_api(struct ft_arguments &arguments)
 
   // Register a completion callback
   transmitter.register_completion_callback(
-        [&files](uint32_t toi) {
+        [&files](uint32_t toi) -> void {
           for (auto& file : files) {
             if (file.toi == toi) {
               spdlog::info("{} (TOI {}) has been transmitted", file.location, file.toi);

--- a/include/FileDeliveryTable.h
+++ b/include/FileDeliveryTable.h
@@ -116,8 +116,14 @@ namespace LibFlute {
         return _file_entries;
       };
 
+     /**
+      * Mark instance sent
+      */
+      void sent() { _instance_id_sent = _instance_id; };
+
     private:
       uint32_t _instance_id;
+      uint32_t _instance_id_sent;
 
       std::vector<FileEntry> _file_entries;
       FecOti _global_fec_oti;

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -585,7 +585,7 @@ namespace LibFlute {
       void deactivate();
 
      /**
-      * Get number of files currently being sent
+      * Get number of files currently in queue for sending
       *
       * @return The number of files in the queue for sending.
       */
@@ -595,6 +595,7 @@ namespace LibFlute {
       void send_fdt();
       void send_next_packet();
       void fdt_send_tick(const boost::system::error_code& error);
+      void start_fdt_repeat_timer();
 
       void file_transmitted(uint32_t toi);
 

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -33,6 +33,9 @@ namespace LibFlute {
 
   /**
    *  FLUTE transmitter class. Construct an instance of this to send data through a FLUTE/ALC session.
+   *
+   *  The session can be active (sending packets) or inactive (sending of packets paused). This allows the FLUTE session to be
+   *  suspended using the deactivate() method and later resumed using activate().
    */
   class Transmitter {
     public:
@@ -372,13 +375,15 @@ namespace LibFlute {
       *  @param io_context Boost io_context to run the socket operations in (must be provided by the caller)
       *  @param tunnel_endpoint Tunnelling endpoint address (default: no tunnelling)
       *  @param fdt_namespace Which XML namespace to use for the FDT (default: none)
+      *  @param active Start as active/inactive FLUTE session (default: active)
       */
       Transmitter( const std::string& address,
           short port, uint64_t tsi, unsigned short mtu,
           uint32_t rate_limit,
           boost::asio::io_context& io_context,
           const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint = std::nullopt,
-          FdtNamespace fdt_namespace = FileDeliveryTable::FDT_NS_NONE);
+          FdtNamespace fdt_namespace = FileDeliveryTable::FDT_NS_NONE,
+          bool active = true);
 
      /**
       *  Default destructor.
@@ -560,10 +565,36 @@ namespace LibFlute {
       */
       void register_completion_callback(completion_callback_t cb) { _completion_cb = cb; };
 
+     /**
+      * Activate the FLUTE session
+      *
+      * If the Transmitter is currently deactivated then the state is set to active and the FLUTE stream will start transmitting.
+      * Sending of packets will start or resume until the deactivate() method is called or this Transmitter is destroyed.
+      */
+      void activate();
+
+     /**
+      * Deactivate the FLUTE session
+      *
+      * If the Transmitter is currently active then the FLUTE stream is halted and the state is changed to deactivated. Sending of
+      * packets will be halted until the activate() method is called. Note that this will pause File transmission part way through
+      * if a File is currently being transmitted. If the application wishes for deactivation once Files have finished sending then
+      * it should only deactivate() when the completion callback is called and number_of_files() equals 0 to ensure all Files have
+      * been completely transmitted.
+      */
+      void deactivate();
+
+     /**
+      * Get number of files currently being sent
+      *
+      * @return The number of files in the queue for sending.
+      */
+      size_t number_of_files() { std::lock_guard<std::mutex> guard(_files_mutex); return _files.size(); };
+
     private:
       void send_fdt();
       void send_next_packet();
-      void fdt_send_tick();
+      void fdt_send_tick(const boost::system::error_code& error);
 
       void file_transmitted(uint32_t toi);
 
@@ -593,6 +624,8 @@ namespace LibFlute {
       uint32_t _rate_limit = 0;
       std::optional<boost::asio::ip::udp::endpoint> _tunnel_endpoint = std::nullopt;
       boost::asio::ip::address _tunnel_local_address;
+
+      bool _active;
   };
 
 } // end namespace LibFlute

--- a/src/AlcPacket.cpp
+++ b/src/AlcPacket.cpp
@@ -211,7 +211,6 @@ LibFlute::AlcPacket::AlcPacket(uint16_t tsi, uint16_t toi, LibFlute::FecOti fec_
     *((uint16_t*)hdr_ptr) = htons(_fec_oti.encoding_symbol_length);
     hdr_ptr += 2;
     *((uint32_t*)hdr_ptr) = htonl(_fec_oti.max_source_block_length);
-    //hdr_ptr += 4;
   }
 }
 

--- a/src/AlcPacket.cpp
+++ b/src/AlcPacket.cpp
@@ -211,7 +211,7 @@ LibFlute::AlcPacket::AlcPacket(uint16_t tsi, uint16_t toi, LibFlute::FecOti fec_
     *((uint16_t*)hdr_ptr) = htons(_fec_oti.encoding_symbol_length);
     hdr_ptr += 2;
     *((uint32_t*)hdr_ptr) = htonl(_fec_oti.max_source_block_length);
-    hdr_ptr += 4;
+    //hdr_ptr += 4;
   }
 }
 

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -133,6 +133,7 @@ bool LibFlute::FileDeliveryTable::FileEntry::operator==(const LibFlute::FileDeli
 
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_oti, FdtNamespace fdt_namespace)
   : _instance_id( instance_id )
+  , _instance_id_sent( instance_id - 1 )
   , _global_fec_oti( fec_oti )
   , _fdt_namespace( fdt_namespace )
 {
@@ -140,6 +141,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, FecOti fec_
 
 LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffer, size_t len) 
   : _instance_id( instance_id )
+  , _instance_id_sent( instance_id - 1 )
   , _global_fec_oti()
 {
   static const std::string mbms2007_ns("urn:3GPP:metadata:2007:MBMS:FLUTE:FDT"); // 3GPP TS 26.346 Clause 7.2.10.2
@@ -339,7 +341,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
 
 auto LibFlute::FileDeliveryTable::add(const FileEntry& fe) -> void
 {
-  _instance_id++;
+  if (_instance_id == _instance_id_sent) _instance_id++;
   _file_entries.push_back(fe);
 }
 
@@ -352,7 +354,7 @@ auto LibFlute::FileDeliveryTable::remove(uint32_t toi) -> void
       ++it;
     }
   }
-  _instance_id++;
+  if (_instance_id == _instance_id_sent) _instance_id++;
 }
 
 auto LibFlute::FileDeliveryTable::to_string() const -> std::string {

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -589,6 +589,7 @@ auto Transmitter::seconds_since_epoch() -> uint64_t
 }
 
 auto Transmitter::send_fdt() -> void {
+  if (_fdt->file_entries().empty()) return;
   _fdt->set_expires(seconds_since_epoch() + _fdt_repeat_interval * 2);
   auto fdt = _fdt->to_string();
   auto file = std::make_shared<File>(
@@ -604,6 +605,7 @@ auto Transmitter::send_fdt() -> void {
     file->set_fdt_instance_id( _fdt->instance_id() );
     spdlog::debug("Sending FDT instance {}:\n{}", _fdt->instance_id(), _fdt->to_string());
     _files.insert_or_assign(0, file);
+    _fdt->sent();
   }
 }
 

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -501,8 +501,7 @@ Transmitter::Transmitter ( const std::string& address, short port,
   _fdt = std::make_unique<FileDeliveryTable>(1, _fec_oti, fdt_namespace);
 
   if (_active) {
-    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
-    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+    start_fdt_repeat_timer();
     send_next_packet();
   }
 }
@@ -678,8 +677,7 @@ auto Transmitter::fdt_send_tick(const boost::system::error_code& error) -> void
   if (error == boost::asio::error::operation_aborted) return;
   if (_active) {
     send_fdt();
-    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
-    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+    start_fdt_repeat_timer();
   }
 }
 
@@ -783,8 +781,7 @@ auto Transmitter::activate() -> void
 {
   if (!_active) {
     _active = true;
-    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
-    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+    start_fdt_repeat_timer();
     send_next_packet();
   }
 }
@@ -796,6 +793,12 @@ auto Transmitter::deactivate() -> void
     _fdt_timer.cancel();
     _send_timer.cancel();
   }
+}
+
+auto Transmitter::start_fdt_repeat_timer() -> void
+{
+    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
+    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
 }
 
 static void create_udp_pkt(char *udp_buffer, const boost::asio::ip::udp::endpoint &endpoint, const char *data, size_t data_len, const boost::asio::ip::address &local_address)

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -460,7 +460,7 @@ Transmitter::Transmitter ( const std::string& address, short port,
                            uint64_t tsi, unsigned short mtu, uint32_t rate_limit,
                            boost::asio::io_context& io_context,
                            const std::optional<boost::asio::ip::udp::endpoint> &tunnel_endpoint,
-                           Transmitter::FdtNamespace fdt_namespace )
+                           Transmitter::FdtNamespace fdt_namespace, bool active )
     : _endpoint(boost::asio::ip::make_address(address), port)
     , _socket(io_context, _endpoint.protocol())
     , _io_context(io_context)
@@ -474,6 +474,7 @@ Transmitter::Transmitter ( const std::string& address, short port,
     , _rate_limit(rate_limit)
     , _tunnel_endpoint(tunnel_endpoint)
     , _tunnel_local_address()
+    , _active(active)
 {
   _max_payload = mtu -
     20 - // IPv4 header
@@ -499,10 +500,11 @@ Transmitter::Transmitter ( const std::string& address, short port,
     .max_source_block_length = max_source_block_length};
   _fdt = std::make_unique<FileDeliveryTable>(1, _fec_oti, fdt_namespace);
 
-  _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
-  _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this));
-
-  send_next_packet();
+  if (_active) {
+    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
+    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+    send_next_packet();
+  }
 }
 
 Transmitter::~Transmitter() = default;
@@ -604,7 +606,10 @@ auto Transmitter::send_fdt() -> void {
   if (file) {
     file->set_fdt_instance_id( _fdt->instance_id() );
     spdlog::debug("Sending FDT instance {}:\n{}", _fdt->instance_id(), _fdt->to_string());
-    _files.insert_or_assign(0, file);
+    {
+      std::lock_guard<std::mutex> guard(_files_mutex);
+      _files.insert_or_assign(0, file);
+    }
     _fdt->sent();
   }
 }
@@ -631,7 +636,10 @@ auto Transmitter::send(
 
   _fdt->add(file->meta());
   send_fdt();
-  _files.insert({toi, file});
+  {
+    std::lock_guard<std::mutex> guard(_files_mutex);
+    _files.insert({toi, file});
+  }
   return toi;
 }
 
@@ -656,23 +664,32 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
   file_description->merge_fec_oti(_fec_oti);
 
   auto file = std::make_shared<File>(file_description);
+  {
+    std::lock_guard<std::mutex> guard(_files_mutex);
+    _files.insert({file_description->toi(), file});
+  }
   _fdt->add(file->meta());
   send_fdt();
-  _files.insert({file_description->toi(), file});
   return file_description->toi();
 }
 
-auto Transmitter::fdt_send_tick() -> void
+auto Transmitter::fdt_send_tick(const boost::system::error_code& error) -> void
 {
-  send_fdt();
-  _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
-  _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this));
+  if (error == boost::asio::error::operation_aborted) return;
+  if (_active) {
+    send_fdt();
+    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
+    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+  }
 }
 
 auto Transmitter::file_transmitted(uint32_t toi) -> void
 {
-  if (toi != 0) {
+  {
+    std::lock_guard<std::mutex> guard(_files_mutex);
     _files.erase(toi);
+  }
+  if (toi != 0) {
     _fdt->remove(toi);
     send_fdt();
 
@@ -686,71 +703,98 @@ auto Transmitter::send_next_packet() -> void
 {
   uint32_t bytes_queued = 0;
 
-  if (_files.size()) {
+  if (!_active) return;
+  std::shared_ptr<File> file;
+  {
+    std::lock_guard<std::mutex> guard(_files_mutex);
     for (auto& file_m : _files) {
-      auto file = file_m.second;
+      auto &next_file = file_m.second;
 
-      if (file && !file->complete()) {
-        auto symbols = file->get_next_symbols(_max_payload);
-
-        if (symbols.size()) {
-          for(const auto& symbol : symbols) {
-            spdlog::debug("sending TOI {} SBN {} ID {}", file->meta().toi, symbol.source_block_number(), symbol.id() );
-          }
-          auto packet = std::make_shared<AlcPacket>(_tsi, file->meta().toi, file->meta().fec_oti, symbols, _max_payload, file->fdt_instance_id());
-          bytes_queued += packet->size();
-
-	  boost::asio::ip::udp::endpoint send_endpoint;
-          char *data = nullptr;
-          size_t data_size = 0;
-	  if (_tunnel_endpoint) {
-	    send_endpoint = _tunnel_endpoint.value();
-	    data_size = packet->size() + 20 /* IP header */ + 8 /* UDP header */;
-            data = new char[data_size];
-	    create_udp_pkt(data+20, _endpoint, packet->data(), packet->size(), _tunnel_local_address);
-	    create_ip_hdr(data, _endpoint, data_size, _tunnel_local_address);
-	  } else {
-            send_endpoint = _endpoint;
-	    data = packet->data();
-            data_size = packet->size();
-          }
-          _socket.async_send_to(
-              boost::asio::buffer(data, data_size), send_endpoint,
-              [file, symbols, packet, this](
-                const boost::system::error_code& error,
-                std::size_t bytes_transferred)
-              {
-                if (error) {
-                  spdlog::debug("sent_to error: {}", error.message());
-                } else {
-                  file->mark_completed(symbols, !error);
-                  if (file->complete()) {
-                    file_transmitted(file->meta().toi);
-                  }
-                }
-              });
-          if (_tunnel_endpoint) {
-	    delete[] data;
-          }
-        }
+      if (next_file && !next_file->complete()) {
+        file = next_file;
         break;
       }
     }
   }
-  if (!bytes_queued) {
-    _send_timer.expires_from_now(boost::posix_time::milliseconds(10));
-    _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
-  } else {
-    if (_rate_limit == 0) {
-      boost::asio::post(_io_context, boost::bind(&Transmitter::send_next_packet, this));
-    } else {
-      auto send_duration = ((bytes_queued * 8.0) / (double)_rate_limit/1000.0) * 1000.0 * 1000.0;
-      spdlog::trace("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us",
-          bytes_queued, _rate_limit, send_duration);
-      _send_timer.expires_from_now(boost::posix_time::microseconds(
-            static_cast<int>(ceil(send_duration))));
-      _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
+  if (file) {
+    auto symbols = file->get_next_symbols(_max_payload);
+
+    if (symbols.size()) {
+      for(const auto& symbol : symbols) {
+        spdlog::debug("sending TOI {} SBN {} ID {}", file->meta().toi, symbol.source_block_number(), symbol.id() );
+      }
+      auto packet = std::make_shared<AlcPacket>(_tsi, file->meta().toi, file->meta().fec_oti, symbols, _max_payload, file->fdt_instance_id());
+      bytes_queued += packet->size();
+
+      boost::asio::ip::udp::endpoint send_endpoint;
+      char *data = nullptr;
+      size_t data_size = 0;
+      if (_tunnel_endpoint) {
+        send_endpoint = _tunnel_endpoint.value();
+        data_size = packet->size() + 20 /* IP header */ + 8 /* UDP header */;
+        data = new char[data_size];
+        create_udp_pkt(data+20, _endpoint, packet->data(), packet->size(), _tunnel_local_address);
+        create_ip_hdr(data, _endpoint, data_size, _tunnel_local_address);
+      } else {
+        send_endpoint = _endpoint;
+        data = packet->data();
+        data_size = packet->size();
+      }
+      _socket.async_send_to(
+          boost::asio::buffer(data, data_size), send_endpoint,
+          [file, symbols, packet, this](
+              const boost::system::error_code& error,
+              std::size_t bytes_transferred)
+          {
+            if (error) {
+              spdlog::debug("sent_to error: {}", error.message());
+            } else {
+              file->mark_completed(symbols, !error);
+              if (file->complete()) {
+                file_transmitted(file->meta().toi);
+              }
+            }
+          });
+      if (_tunnel_endpoint) {
+        delete[] data;
+      }
     }
+  }
+  if (_active) {
+    if (!bytes_queued) {
+      _send_timer.expires_from_now(boost::posix_time::milliseconds(10));
+      _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
+    } else {
+      if (_rate_limit == 0) {
+        boost::asio::post(_io_context, boost::bind(&Transmitter::send_next_packet, this));
+      } else {
+        auto send_duration = ((bytes_queued * 8.0) / (double)_rate_limit/1000.0) * 1000.0 * 1000.0;
+        spdlog::trace("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us",
+            bytes_queued, _rate_limit, send_duration);
+        _send_timer.expires_from_now(boost::posix_time::microseconds(
+              static_cast<int>(ceil(send_duration))));
+        _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
+      }
+    }
+  }
+}
+
+auto Transmitter::activate() -> void
+{
+  if (!_active) {
+    _active = true;
+    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
+    _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
+    send_next_packet();
+  }
+}
+
+auto Transmitter::deactivate() -> void
+{
+  if (_active) {
+    _active = false;
+    _fdt_timer.cancel();
+    _send_timer.cancel();
   }
 }
 
@@ -801,19 +845,19 @@ static void create_ip_hdr(char *ip_buffer, const boost::asio::ip::udp::endpoint 
 
 static uint16_t calculate_sum(uint16_t *buffer, size_t len)
 {
-    uint32_t cksum = 0;
+  uint32_t cksum = 0;
 
-    while (len > 1) {
-	cksum += ntohs(*buffer);
-        len -= 2;
-        buffer++;
-    }
-    if (len > 0) {
-        cksum = *reinterpret_cast<uint8_t*>(buffer);
-    }
-    uint16_t result = ~htons(static_cast<uint16_t>(cksum & 0xFFFF) + static_cast<uint16_t>(cksum >> 16));
+  while (len > 1) {
+    cksum += ntohs(*buffer);
+    len -= 2;
+    buffer++;
+  }
+  if (len > 0) {
+    cksum = *reinterpret_cast<uint8_t*>(buffer);
+  }
+  uint16_t result = ~htons(static_cast<uint16_t>(cksum & 0xFFFF) + static_cast<uint16_t>(cksum >> 16));
 
-    return result;
+  return result;
 }
 
 } // End namespace LibFlute


### PR DESCRIPTION
This PR stops empty FDTs from being transmitted and adds `Transmitter` object methods to activate or deactivate the transmission of the FLUTE session.

## FDT improvements

The FDT is no longer transmitted in the FLUTE session if it doesn't contain at least one item. This complies with [RFC 3926 section 3.2](https://www.rfc-editor.org/rfc/rfc3926.html#section-3.2):
> An FDT Instance contains one or more file description entries of the FDT.

As a result, an empty FDT is never transmitted.

The incrementing of the FDT instance ID has also been improved to reduce the number of increments. The value is now incremented by only 1 between transmitted instances of the FDT, even when multiple changes are made to the FDT between transmissions.

## Activity lifecycle

The `Transmitter` object can now be in an **active** or **inactive** state, allowing the FLUTE session to be paused and resumed.

- In the active state, packets are transmitted for the FDT and file transmission objects.
- In the inactive state, no packets are transmitted. In this state, the list of files to transmit can still be modified, and the resulting packets are sent once the `Transmitter` object becomes active.

The following methods are used in conjunction with this:
- The `Transmitter` constructor method can now take an optional indicator to determine if instances should start in the active or inactive state.
- An `activate()` method is introduced to activate the `Transmitter` if it is currently in the inactive state.
- A `deactivate()` method is introduced to change the `Transmitter` object to the inactive state if it is currently active.
- A `number_of_files()` method is added to interrogate the `Transmitter` object for how many files it has left to transmit. This allows applications to monitor the `Transmitter` object in order to drain the *File* transmissions before calling `deactivate()`.

## Issues fixed by this PR

Closes #19
Closes #47
