### PR TITLE
Fix UDP checksum calculation for tunnelled FLUTE packets

### DIFF
--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -856,7 +856,7 @@ static uint16_t calculate_sum(uint16_t *buffer, size_t len)
     buffer++;
   }
   if (len > 0) {
-    cksum = *reinterpret_cast<uint8_t*>(buffer);
+    cksum += (*reinterpret_cast<uint8_t*>(buffer)) << 8;
   }
   uint16_t result = ~htons(static_cast<uint16_t>(cksum & 0xFFFF) + static_cast<uint16_t>(cksum >> 16));
 


### PR DESCRIPTION
Related to https://github.com/5G-MAG/rt-mbs-transport-function/issues/52.

The UDP checksum calculation seemed to be wrong. I found this by using Github's Copilot, so I don't really understand the fix. But after applying this change, flute-receiver is able to receive all the files sent by the MBSTF.