### PR TITLE
More fixes to UDP checksum calculation for tunnelled FLUTE packets

### DIFF
--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -858,7 +858,12 @@ static uint16_t calculate_sum(uint16_t *buffer, size_t len)
   if (len > 0) {
     cksum += (*reinterpret_cast<uint8_t*>(buffer)) << 8;
   }
-  uint16_t result = ~htons(static_cast<uint16_t>(cksum & 0xFFFF) + static_cast<uint16_t>(cksum >> 16));
+  
+  while (cksum >> 16) {
+    cksum = (cksum & 0xFFFF) + (cksum >> 16);
+  }
+
+  uint16_t result = htons(static_cast<uint16_t>(~cksum));
 
   return result;
 }


### PR DESCRIPTION
Further to bugfix #51, @jordijoangimenez, @jsroldan and I were testing the [DASH pull operation of the MBSTF tutorial](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbstf.html#step-7-create-a-streaming-mbs-distribution-session-for-pull-operation-on-the-dash-manifest) and we found another problem with the UDP checksum calculation in the MBSTF.

This time we detected that some of the packets are off by one (e.g. 0xff9d instead of 0xff9c). This caused the flute-receiver to not read most of the files send to the multicast group.

The fix has been proposed by ChatGPT, so we don't fully understand the fix. After applying and testing the fix, we are able to receive every file sent by the MBSTF, and we don't see the checksum issue anymore.