### PR TITLE
Feature/end to end test tunneled mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 build/
 .idea
 cmake-build-debug/
+build-release/

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -725,25 +725,31 @@ auto Transmitter::send_next_packet() -> void
       bytes_queued += packet->size();
 
       boost::asio::ip::udp::endpoint send_endpoint;
-      char *data = nullptr;
+      const char *data = nullptr;
       size_t data_size = 0;
+      std::shared_ptr<std::vector<char>> tunnel_data;
       if (_tunnel_endpoint) {
         send_endpoint = _tunnel_endpoint.value();
         data_size = packet->size() + 20 /* IP header */ + 8 /* UDP header */;
-        data = new char[data_size];
-        create_udp_pkt(data+20, _endpoint, packet->data(), packet->size(), _tunnel_local_address);
-        create_ip_hdr(data, _endpoint, data_size, _tunnel_local_address);
+        tunnel_data = std::make_shared<std::vector<char>>(data_size);
+        data = tunnel_data->data();
+        create_udp_pkt(const_cast<char*>(data) + 20, _endpoint, packet->data(), packet->size(), _tunnel_local_address);
+        create_ip_hdr(const_cast<char*>(data), _endpoint, data_size, _tunnel_local_address);
       } else {
         send_endpoint = _endpoint;
         data = packet->data();
         data_size = packet->size();
       }
       _socket.async_send_to(
-          boost::asio::buffer(data, data_size), send_endpoint,
-          [file, symbols, packet, this](
+          boost::asio::buffer(data, data_size),
+          send_endpoint,
+          [file, symbols, packet, tunnel_data, this](
               const boost::system::error_code& error,
               std::size_t bytes_transferred)
           {
+            (void)packet;
+            (void)tunnel_data;
+            (void)bytes_transferred;
             if (error) {
               spdlog::debug("sent_to error: {}", error.message());
             } else {
@@ -753,9 +759,6 @@ auto Transmitter::send_next_packet() -> void
               }
             }
           });
-      if (_tunnel_endpoint) {
-        delete[] data;
-      }
     }
   }
   if (_active) {
@@ -858,7 +861,7 @@ static uint16_t calculate_sum(uint16_t *buffer, size_t len)
   if (len > 0) {
     cksum += (*reinterpret_cast<uint8_t*>(buffer)) << 8;
   }
-  
+
   while (cksum >> 16) {
     cksum = (cksum & 0xFFFF) + (cksum >> 16);
   }
@@ -869,4 +872,3 @@ static uint16_t calculate_sum(uint16_t *buffer, size_t len)
 }
 
 } // End namespace LibFlute
-

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -52,7 +52,9 @@ static void create_udp_pkt( char *udp_buffer, const boost::asio::ip::udp::endpoi
                             const boost::asio::ip::address &local_address );
 static void create_ip_hdr( char *ip_buffer, const boost::asio::ip::udp::endpoint &endpoint, size_t pkt_size,
                            const boost::asio::ip::address &local_address );
-static uint16_t calculate_sum( uint16_t *buffer, size_t len );
+static uint16_t calculate_sum( const uint8_t *buffer, size_t len );
+static void write_uint16_be( uint8_t *buffer, uint16_t value );
+static void write_uint32_be( uint8_t *buffer, uint32_t value );
 
 /*****************************************************************************
  * Transmitter::FileDescription class
@@ -806,69 +808,77 @@ auto Transmitter::start_fdt_repeat_timer() -> void
 
 static void create_udp_pkt(char *udp_buffer, const boost::asio::ip::udp::endpoint &endpoint, const char *data, size_t data_len, const boost::asio::ip::address &local_address)
 {
-  struct udp_pseudo_hdr {
-    in_addr_t source;
-    in_addr_t dest;
-    uint8_t reserved;
-    uint8_t protocol;
-    uint16_t length;
-  } *pseudo_hdr = reinterpret_cast<struct udp_pseudo_hdr*>(udp_buffer - sizeof(*pseudo_hdr));
-  struct udphdr *udp_hdr = reinterpret_cast<struct udphdr*>(udp_buffer);
+  auto *udp_bytes = reinterpret_cast<uint8_t*>(udp_buffer);
+  const auto udp_length = static_cast<uint16_t>(data_len + 8);
+  const auto source_address = local_address.to_v4().to_uint();
+  const auto destination_address = endpoint.address().to_v4().to_uint();
 
-  pseudo_hdr->source = htonl(local_address.to_v4().to_uint());
-  pseudo_hdr->dest = htonl(endpoint.address().to_v4().to_uint());
-  pseudo_hdr->reserved = 0;
-  pseudo_hdr->protocol = endpoint.protocol().protocol();
-  pseudo_hdr->length = htons(data_len + 8);
+  write_uint16_be(udp_bytes, endpoint.port());
+  write_uint16_be(udp_bytes + 2, endpoint.port());
+  write_uint16_be(udp_bytes + 4, udp_length);
+  write_uint16_be(udp_bytes + 6, 0);
+  memcpy(udp_buffer + 8, data, data_len);
 
-  udp_hdr->uh_sport = htons(endpoint.port());
-  udp_hdr->uh_dport = udp_hdr->uh_sport;
-  udp_hdr->uh_ulen = pseudo_hdr->length;
-  udp_hdr->uh_sum = 0;
-  memcpy(udp_buffer+8, data, data_len);
+  std::vector<uint8_t> checksum_bytes(12 + udp_length);
+  write_uint32_be(checksum_bytes.data(), source_address);
+  write_uint32_be(checksum_bytes.data() + 4, destination_address);
+  checksum_bytes[8] = 0;
+  checksum_bytes[9] = endpoint.protocol().protocol();
+  write_uint16_be(checksum_bytes.data() + 10, udp_length);
+  memcpy(checksum_bytes.data() + 12, udp_bytes, udp_length);
 
-  udp_hdr->uh_sum = calculate_sum(reinterpret_cast<uint16_t*>(pseudo_hdr), data_len + 8 + 12);
+  write_uint16_be(udp_bytes + 6, calculate_sum(checksum_bytes.data(), checksum_bytes.size()));
 }
 
 static void create_ip_hdr(char *ip_buffer, const boost::asio::ip::udp::endpoint &endpoint, size_t pkt_size, const boost::asio::ip::address &local_address)
 {
-  struct iphdr *ip_hdr = reinterpret_cast<struct iphdr*>(ip_buffer);
+  auto *ip_bytes = reinterpret_cast<uint8_t*>(ip_buffer);
 
-  ip_hdr->version = IPVERSION;
-  ip_hdr->ihl = 5; // 20 bytes
-  ip_hdr->tos = 0;
-  ip_hdr->tot_len = htons(pkt_size);
-  ip_hdr->id = 0;
-  ip_hdr->frag_off = 0; // not fragmenting
-  ip_hdr->ttl = 63; // TTL 63 hops
-  ip_hdr->protocol = endpoint.protocol().protocol();
-  ip_hdr->check = 0;
-  ip_hdr->saddr = htonl(local_address.to_v4().to_uint());
-  ip_hdr->daddr = htonl(endpoint.address().to_v4().to_uint());
-
-  ip_hdr->check = calculate_sum(reinterpret_cast<uint16_t*>(ip_hdr), 20);
+  memset(ip_bytes, 0, 20);
+  ip_bytes[0] = 0x45; // IPv4, 20-byte header
+  ip_bytes[1] = 0;
+  write_uint16_be(ip_bytes + 2, static_cast<uint16_t>(pkt_size));
+  write_uint16_be(ip_bytes + 4, 0);
+  write_uint16_be(ip_bytes + 6, 0);
+  ip_bytes[8] = 63;
+  ip_bytes[9] = endpoint.protocol().protocol();
+  write_uint32_be(ip_bytes + 12, local_address.to_v4().to_uint());
+  write_uint32_be(ip_bytes + 16, endpoint.address().to_v4().to_uint());
+  write_uint16_be(ip_bytes + 10, calculate_sum(ip_bytes, 20));
 }
 
-static uint16_t calculate_sum(uint16_t *buffer, size_t len)
+static uint16_t calculate_sum(const uint8_t *buffer, size_t len)
 {
   uint32_t cksum = 0;
 
   while (len > 1) {
-    cksum += ntohs(*buffer);
+    cksum += (static_cast<uint32_t>(buffer[0]) << 8) | static_cast<uint32_t>(buffer[1]);
     len -= 2;
-    buffer++;
+    buffer += 2;
   }
   if (len > 0) {
-    cksum += (*reinterpret_cast<uint8_t*>(buffer)) << 8;
+    cksum += static_cast<uint32_t>(buffer[0]) << 8;
   }
 
   while (cksum >> 16) {
     cksum = (cksum & 0xFFFF) + (cksum >> 16);
   }
 
-  uint16_t result = htons(static_cast<uint16_t>(~cksum));
+  return static_cast<uint16_t>(~cksum);
+}
 
-  return result;
+static void write_uint16_be(uint8_t *buffer, uint16_t value)
+{
+  buffer[0] = static_cast<uint8_t>((value >> 8) & 0xFF);
+  buffer[1] = static_cast<uint8_t>(value & 0xFF);
+}
+
+static void write_uint32_be(uint8_t *buffer, uint32_t value)
+{
+  buffer[0] = static_cast<uint8_t>((value >> 24) & 0xFF);
+  buffer[1] = static_cast<uint8_t>((value >> 16) & 0xFF);
+  buffer[2] = static_cast<uint8_t>((value >> 8) & 0xFF);
+  buffer[3] = static_cast<uint8_t>(value & 0xFF);
 }
 
 } // End namespace LibFlute

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -18,63 +18,300 @@
 
 #include <boost/asio.hpp>
 
+#include <arpa/inet.h>
+#include <netinet/ip.h>
+#include <netinet/udp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
 #include <chrono>
-#include <filesystem>
-#include <fstream>
+#include <cstdint>
+#include <cstring>
 #include <future>
 #include <iostream>
-#include <iterator>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "Receiver.h"
 #include "Transmitter.h"
 
 namespace {
 
-auto read_fixture_file(const std::filesystem::path& file_path) -> std::string {
-  std::ifstream input(file_path, std::ios::binary);
-  if (!input.is_open()) {
-    throw std::runtime_error("Failed to open end-to-end fixture file");
-  }
+using namespace std::chrono_literals;
 
-  return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+constexpr short kPort = 18091;
+constexpr short kTunnelPort = 18092;
+constexpr uint64_t kTsi = 4242;
+constexpr unsigned short kMtu = 1400;
+constexpr size_t kTunnelPayloadLimit = kMtu - 20 - 8;
+
+struct TunnelBridgeStats {
+  size_t received_packet_count = 0;
+  size_t forwarded_packet_count = 0;
+  size_t max_tunnel_payload_size = 0;
+  std::string error;
+};
+
+struct EndToEndOptions {
+  bool tunneled = false;
+};
+
+auto make_test_payload() -> std::vector<char> {
+  std::vector<char> payload(5000);
+  for (size_t i = 0; i < payload.size(); ++i) {
+    payload[i] = static_cast<char>('A' + (i % 26));
+  }
+  return payload;
 }
 
-}  // namespace
+auto calculate_checksum_host_order(const uint8_t* data, size_t length) -> uint16_t {
+  uint32_t checksum = 0;
 
-TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
-  namespace fs = std::filesystem;
-  using namespace std::chrono_literals;
+  for (size_t i = 0; i + 1 < length; i += 2) {
+    checksum += (static_cast<uint32_t>(data[i]) << 8) | static_cast<uint32_t>(data[i + 1]);
+  }
+  if ((length % 2) != 0) {
+    checksum += static_cast<uint32_t>(data[length - 1]) << 8;
+  }
 
-  constexpr short kPort = 18091;
-  const fs::path fixtures_dir = fs::path{__FILE__}.parent_path() / "tmp";
-  const fs::path input_file = fixtures_dir / "e2e_payload.bin";
-  const std::string expected_location = "e2e/payload.bin";
-  const std::string expected_payload = read_fixture_file(input_file);
+  while ((checksum >> 16U) != 0U) {
+    checksum = (checksum & 0xFFFFU) + (checksum >> 16U);
+  }
+
+  return static_cast<uint16_t>(~checksum & 0xFFFFU);
+}
+
+auto calculate_ipv4_header_checksum(const iphdr& header, size_t header_length) -> uint16_t {
+  std::vector<uint8_t> bytes(header_length);
+  std::memcpy(bytes.data(), &header, header_length);
+
+  auto* header_copy = reinterpret_cast<iphdr*>(bytes.data());
+  header_copy->check = 0;
+
+  return calculate_checksum_host_order(bytes.data(), bytes.size());
+}
+
+auto calculate_udp_checksum(const iphdr& ip_header, const udphdr& udp_header, const uint8_t* payload,
+                            size_t payload_length) -> uint16_t {
+  const size_t udp_length = sizeof(udphdr) + payload_length;
+  std::vector<uint8_t> bytes(12 + udp_length);
+
+  std::memcpy(bytes.data(), &ip_header.saddr, sizeof(ip_header.saddr));
+  std::memcpy(bytes.data() + 4, &ip_header.daddr, sizeof(ip_header.daddr));
+  bytes[8] = 0;
+  bytes[9] = static_cast<uint8_t>(ip_header.protocol);
+  bytes[10] = static_cast<uint8_t>((udp_length >> 8) & 0xFFU);
+  bytes[11] = static_cast<uint8_t>(udp_length & 0xFFU);
+
+  std::memcpy(bytes.data() + 12, &udp_header, sizeof(udphdr));
+  auto* udp_header_copy = reinterpret_cast<udphdr*>(bytes.data() + 12);
+  udp_header_copy->uh_sum = 0;
+  std::memcpy(bytes.data() + 12 + sizeof(udphdr), payload, payload_length);
+
+  return calculate_checksum_host_order(bytes.data(), bytes.size());
+}
+
+auto set_socket_timeout(int socket_fd, std::chrono::milliseconds timeout) -> void {
+  timeval socket_timeout{};
+  socket_timeout.tv_sec = static_cast<time_t>(timeout.count() / 1000);
+  socket_timeout.tv_usec = static_cast<suseconds_t>((timeout.count() % 1000) * 1000);
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &socket_timeout, sizeof(socket_timeout)) != 0) {
+    throw std::runtime_error("Failed to set tunnel bridge socket timeout");
+  }
+}
+
+auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
+                       TunnelBridgeStats& stats) -> void {
+  int receive_socket = -1;
+  int forward_socket = -1;
+
+  try {
+    receive_socket = socket(AF_INET, SOCK_DGRAM, 0);
+    forward_socket = socket(AF_INET, SOCK_DGRAM, 0);
+    if (receive_socket < 0 || forward_socket < 0) {
+      throw std::runtime_error("Failed to open tunnel bridge sockets");
+    }
+
+    const int reuse = 1;
+    if (setsockopt(receive_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
+      throw std::runtime_error("Failed to set tunnel bridge socket reuse");
+    }
+
+    sockaddr_in receive_address{};
+    receive_address.sin_family = AF_INET;
+    receive_address.sin_port = htons(kTunnelPort);
+    receive_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(receive_socket, reinterpret_cast<const sockaddr*>(&receive_address), sizeof(receive_address)) != 0) {
+      throw std::runtime_error("Failed to bind tunnel bridge socket");
+    }
+
+    set_socket_timeout(receive_socket, 200ms);
+    ready_promise.set_value();
+
+    sockaddr_in forward_address{};
+    forward_address.sin_family = AF_INET;
+    forward_address.sin_port = htons(kPort);
+    forward_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    const uint32_t expected_destination =
+        htonl(boost::asio::ip::make_address_v4("239.255.0.1").to_uint());
+    std::vector<uint8_t> buffer(2048);
+
+    while (!stop_requested.load()) {
+      sockaddr_in sender_address{};
+      socklen_t sender_length = sizeof(sender_address);
+      const ssize_t received_bytes = recvfrom(receive_socket,
+                                              buffer.data(),
+                                              buffer.size(),
+                                              0,
+                                              reinterpret_cast<sockaddr*>(&sender_address),
+                                              &sender_length);
+      if (received_bytes < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+          continue;
+        }
+        throw std::runtime_error("Tunnel bridge failed to receive packet");
+      }
+
+      const size_t packet_size = static_cast<size_t>(received_bytes);
+      stats.received_packet_count += 1;
+      stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
+
+      if (packet_size > kTunnelPayloadLimit) {
+        throw std::runtime_error("Tunnelled packet exceeded MTU-safe payload size");
+      }
+      if (packet_size < sizeof(iphdr) + sizeof(udphdr)) {
+        throw std::runtime_error("Tunnelled packet too short for inner IP/UDP headers");
+      }
+
+      const auto* ip_header = reinterpret_cast<const iphdr*>(buffer.data());
+      const size_t ip_header_length = static_cast<size_t>(ip_header->ihl) * 4U;
+      if (ip_header->version != 4 || ip_header_length < sizeof(iphdr)) {
+        throw std::runtime_error("Tunnelled packet contained invalid inner IPv4 header");
+      }
+      if (packet_size < ip_header_length + sizeof(udphdr)) {
+        throw std::runtime_error("Tunnelled packet shorter than declared inner IP header");
+      }
+      if (ntohs(ip_header->tot_len) != packet_size) {
+        throw std::runtime_error("Tunnelled packet inner IPv4 total length mismatch");
+      }
+      if (ip_header->protocol != IPPROTO_UDP) {
+        throw std::runtime_error("Tunnelled packet inner protocol was not UDP");
+      }
+      if (ip_header->daddr != expected_destination) {
+        throw std::runtime_error("Tunnelled packet inner IPv4 destination mismatch");
+      }
+      if (calculate_ipv4_header_checksum(*ip_header, ip_header_length) != ntohs(ip_header->check)) {
+        throw std::runtime_error("Tunnelled packet inner IPv4 checksum mismatch");
+      }
+
+      const auto* udp_header = reinterpret_cast<const udphdr*>(buffer.data() + ip_header_length);
+      const size_t udp_length = ntohs(udp_header->uh_ulen);
+      if (udp_length < sizeof(udphdr) || ip_header_length + udp_length != packet_size) {
+        throw std::runtime_error("Tunnelled packet inner UDP length mismatch");
+      }
+      if (ntohs(udp_header->uh_sport) != kPort || ntohs(udp_header->uh_dport) != kPort) {
+        throw std::runtime_error("Tunnelled packet inner UDP ports mismatch");
+      }
+      if (udp_header->uh_sum == 0) {
+        throw std::runtime_error("Tunnelled packet inner UDP checksum missing");
+      }
+
+      const size_t flute_payload_size = udp_length - sizeof(udphdr);
+      const auto* flute_payload = buffer.data() + ip_header_length + sizeof(udphdr);
+      if (calculate_udp_checksum(*ip_header, *udp_header, flute_payload, flute_payload_size) !=
+          ntohs(udp_header->uh_sum)) {
+        throw std::runtime_error("Tunnelled packet inner UDP checksum mismatch");
+      }
+
+      const ssize_t forwarded_bytes = sendto(forward_socket,
+                                             flute_payload,
+                                             flute_payload_size,
+                                             0,
+                                             reinterpret_cast<const sockaddr*>(&forward_address),
+                                             sizeof(forward_address));
+      if (forwarded_bytes != static_cast<ssize_t>(flute_payload_size)) {
+        throw std::runtime_error("Tunnel bridge failed to forward FLUTE payload");
+      }
+
+      stats.forwarded_packet_count += 1;
+    }
+  } catch (const std::exception& ex) {
+    if (stats.error.empty()) {
+      stats.error = ex.what();
+    }
+    stop_requested.store(true);
+    try {
+      ready_promise.set_value();
+    } catch (const std::future_error&) {
+    }
+  }
+
+  if (receive_socket >= 0) {
+    close(receive_socket);
+  }
+  if (forward_socket >= 0) {
+    close(forward_socket);
+  }
+}
+
+auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
+  const std::string expected_location = options.tunneled ? "e2e/tunnelled-payload.bin" : "e2e/payload.bin";
+  const std::vector<char> expected_payload = make_test_payload();
   const auto now = std::chrono::system_clock::now();
 
   ASSERT_FALSE(expected_payload.empty());
 
+  std::promise<void> tunnel_ready_promise;
+  std::future<void> tunnel_ready_future;
+  std::atomic<bool> tunnel_stop_requested = false;
+  TunnelBridgeStats tunnel_stats;
+  std::thread tunnel_thread;
+
+  std::optional<boost::asio::ip::udp::endpoint> tunnel_endpoint = std::nullopt;
+  if (options.tunneled) {
+    tunnel_ready_future = tunnel_ready_promise.get_future();
+    tunnel_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), kTunnelPort);
+    tunnel_thread = std::thread(
+        [ready_promise = std::move(tunnel_ready_promise), &tunnel_stop_requested, &tunnel_stats]() mutable {
+          run_tunnel_bridge(std::move(ready_promise), tunnel_stop_requested, tunnel_stats);
+        });
+    const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
+    if (tunnel_ready != std::future_status::ready) {
+      tunnel_stop_requested.store(true);
+      if (tunnel_thread.joinable()) {
+        tunnel_thread.join();
+      }
+      FAIL() << "Timed out waiting for tunnel bridge to start";
+    }
+    ASSERT_TRUE(tunnel_stats.error.empty()) << tunnel_stats.error;
+  }
+
   boost::asio::io_context receiver_io;
   boost::asio::io_context transmitter_io;
 
-  LibFlute::Receiver receiver("0.0.0.0", "239.255.0.1", kPort, 4242, receiver_io);
+  LibFlute::Receiver receiver("0.0.0.0", "239.255.0.1", kPort, kTsi, receiver_io);
   LibFlute::Transmitter transmitter(
       "239.255.0.1",
       kPort,
-      4242,
-      1400,
+      kTsi,
+      kMtu,
       0,
       transmitter_io,
-      std::nullopt,
+      tunnel_endpoint,
       LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
 
   auto file_description = std::make_shared<LibFlute::Transmitter::FileDescription>(
       expected_location,
-      input_file.string());
+      expected_payload);
   file_description->set_content_type("application/octet-stream");
   file_description->set_expiry_time(now + 60s);
 
@@ -104,8 +341,8 @@ TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
   std::thread receiver_thread([&receiver_io]() { receiver_io.run(); });
   std::thread transmitter_thread([&transmitter_io]() { transmitter_io.run(); });
 
-  std::cout << "Sending fixture '" << input_file.string() << "' as '" << expected_location
-            << "' with " << expected_payload.size() << " bytes" << std::endl;
+  std::cout << "Sending payload as '" << expected_location << "' with " << expected_payload.size()
+            << " bytes" << (options.tunneled ? " through UDP tunnel" : "") << std::endl;
   transmitter.send(file_description);
 
   const auto transmitted_ready = transmitted_toi_future.wait_for(5s);
@@ -128,6 +365,13 @@ TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
     transmitter_thread.join();
   }
 
+  if (options.tunneled) {
+    tunnel_stop_requested.store(true);
+    if (tunnel_thread.joinable()) {
+      tunnel_thread.join();
+    }
+  }
+
   ASSERT_EQ(transmitted_ready, std::future_status::ready);
   ASSERT_EQ(received_ready, std::future_status::ready);
 
@@ -140,6 +384,28 @@ TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
   EXPECT_EQ(received_file->meta().content_location, expected_location);
   EXPECT_EQ(received_file->meta().content_length, expected_payload.size());
 
+  const std::string expected_payload_string(expected_payload.begin(), expected_payload.end());
   const std::string received_payload(received_file->buffer(), received_file->length());
-  EXPECT_EQ(received_payload, expected_payload);
+  EXPECT_EQ(received_payload, expected_payload_string);
+
+  if (options.tunneled) {
+    ASSERT_TRUE(tunnel_stats.error.empty()) << tunnel_stats.error;
+    EXPECT_GT(tunnel_stats.received_packet_count, 0U);
+    EXPECT_GT(tunnel_stats.forwarded_packet_count, 0U);
+    EXPECT_LE(tunnel_stats.max_tunnel_payload_size, kTunnelPayloadLimit);
+  }
+}
+
+}  // namespace
+
+TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
+  EndToEndOptions options;
+  options.tunneled = false;
+  run_end_to_end_scenario(options);
+}
+
+TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel) {
+  EndToEndOptions options;
+  options.tunneled = true;
+  run_end_to_end_scenario(options);
 }

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -60,6 +60,13 @@ struct TunnelBridgeStats {
   std::string error;
 };
 
+struct TunnelRuntime {
+  std::atomic<bool> stop_requested = false;
+  TunnelBridgeStats stats;
+  std::thread thread;
+  std::optional<boost::asio::ip::udp::endpoint> endpoint = std::nullopt;
+};
+
 struct EndToEndOptions {
   bool tunneled = false;
   std::string expected_location;
@@ -264,6 +271,29 @@ auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop
   }
 }
 
+auto start_tunnel_bridge(TunnelRuntime& tunnel_runtime) -> void {
+  std::future<void> tunnel_ready_future;
+  std::promise<void> tunnel_ready_promise;
+  tunnel_ready_future = tunnel_ready_promise.get_future();
+  tunnel_runtime.endpoint =
+      boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), kTunnelPort);
+  tunnel_runtime.thread =
+      std::thread([ready_promise = std::move(tunnel_ready_promise), &tunnel_runtime]() mutable {
+        run_tunnel_bridge(std::move(ready_promise), tunnel_runtime.stop_requested, tunnel_runtime.stats);
+      });
+
+  const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
+  if (tunnel_ready != std::future_status::ready) {
+    tunnel_runtime.stop_requested.store(true);
+    if (tunnel_runtime.thread.joinable()) {
+      tunnel_runtime.thread.join();
+    }
+    FAIL() << "Timed out waiting for tunnel bridge to start";
+  }
+
+  ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+}
+
 auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
   const std::string expected_location = options.expected_location;
   const std::vector<char> expected_payload = make_test_payload();
@@ -271,29 +301,9 @@ auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
 
   ASSERT_FALSE(expected_payload.empty());
 
-  std::atomic<bool> tunnel_stop_requested = false;
-  TunnelBridgeStats tunnel_stats;
-  std::thread tunnel_thread;
-
-  std::optional<boost::asio::ip::udp::endpoint> tunnel_endpoint = std::nullopt;
+  TunnelRuntime tunnel_runtime;
   if (options.tunneled) {
-    std::future<void> tunnel_ready_future;
-    std::promise<void> tunnel_ready_promise;
-    tunnel_ready_future = tunnel_ready_promise.get_future();
-    tunnel_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), kTunnelPort);
-    tunnel_thread = std::thread(
-        [ready_promise = std::move(tunnel_ready_promise), &tunnel_stop_requested, &tunnel_stats]() mutable {
-          run_tunnel_bridge(std::move(ready_promise), tunnel_stop_requested, tunnel_stats);
-        });
-    const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
-    if (tunnel_ready != std::future_status::ready) {
-      tunnel_stop_requested.store(true);
-      if (tunnel_thread.joinable()) {
-        tunnel_thread.join();
-      }
-      FAIL() << "Timed out waiting for tunnel bridge to start";
-    }
-    ASSERT_TRUE(tunnel_stats.error.empty()) << tunnel_stats.error;
+    start_tunnel_bridge(tunnel_runtime);
   }
 
   boost::asio::io_context receiver_io;
@@ -307,7 +317,7 @@ auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
       kMtu,
       0,
       transmitter_io,
-      tunnel_endpoint,
+      tunnel_runtime.endpoint,
       LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
 
   auto file_description = std::make_shared<LibFlute::Transmitter::FileDescription>(
@@ -367,9 +377,9 @@ auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
   }
 
   if (options.tunneled) {
-    tunnel_stop_requested.store(true);
-    if (tunnel_thread.joinable()) {
-      tunnel_thread.join();
+    tunnel_runtime.stop_requested.store(true);
+    if (tunnel_runtime.thread.joinable()) {
+      tunnel_runtime.thread.join();
     }
   }
 
@@ -390,10 +400,10 @@ auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
   EXPECT_EQ(received_payload, expected_payload_string);
 
   if (options.tunneled) {
-    ASSERT_TRUE(tunnel_stats.error.empty()) << tunnel_stats.error;
-    EXPECT_GT(tunnel_stats.received_packet_count, 0U);
-    EXPECT_GT(tunnel_stats.forwarded_packet_count, 0U);
-    EXPECT_LE(tunnel_stats.max_tunnel_payload_size, kTunnelPayloadLimit);
+    ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+    EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
+    EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
+    EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, kTunnelPayloadLimit);
   }
 }
 

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -150,6 +150,10 @@ namespace
         }
     }
 
+    // In tunneled mode the transmitter sends an outer UDP datagram whose payload is
+    // a complete inner IPv4+UDP packet carrying the FLUTE payload. This helper
+    // detunnels that packet and forwards only the inner FLUTE bytes to the regular
+    // receiver path used by this end-to-end test.
     auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
                            TunnelBridgeStats& stats) -> void
     {
@@ -224,6 +228,8 @@ namespace
                     throw std::runtime_error("Tunnelled packet too short for inner IP/UDP headers");
                 }
 
+                // Validate the encapsulated inner IPv4/UDP headers before forwarding so
+                // the test covers tunnel formatting as well as end-to-end delivery.
                 const auto* ip_header = reinterpret_cast<const iphdr*>(buffer.data());
                 const size_t ip_header_length = static_cast<size_t>(ip_header->ihl) * 4U;
                 if (ip_header->version != 4 || ip_header_length < sizeof(iphdr))
@@ -274,6 +280,8 @@ namespace
                     throw std::runtime_error("Tunnelled packet inner UDP checksum mismatch");
                 }
 
+                // Forward only the inner FLUTE payload. LibFlute::Receiver expects plain
+                // ALC/FLUTE bytes and does not strip tunnel headers on receive.
                 const ssize_t forwarded_bytes = sendto(forward_socket,
                                                        flute_payload,
                                                        flute_payload_size,
@@ -351,6 +359,9 @@ namespace
         TunnelRuntime tunnel_runtime;
         if (options.tunneled)
         {
+            // The bridge is only needed in tunneled mode: it receives encapsulated
+            // packets from the transmitter's tunnel endpoint and re-injects the inner
+            // FLUTE payload onto the receiver's normal UDP port.
             start_tunnel_bridge(tunnel_runtime);
         }
 
@@ -456,6 +467,8 @@ namespace
 
         if (options.tunneled)
         {
+            // Confirm that tunneled delivery really used the bridge and that the
+            // encapsulated packets stayed within the configured MTU-safe payload limit.
             ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
             EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
             EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
@@ -464,6 +477,10 @@ namespace
     }
 } // namespace
 
+
+// Verifies the baseline end-to-end flow without tunnelling: the transmitter
+// sends FLUTE packets directly to the receiver and the reconstructed file
+// matches the original payload and metadata.
 TEST(FluteEndToEndTest, TransmitsFileToReceiver)
 {
     EndToEndOptions options;
@@ -472,6 +489,9 @@ TEST(FluteEndToEndTest, TransmitsFileToReceiver)
     run_end_to_end_scenario(options);
 }
 
+// Verifies tunneled transmission end to end: the transmitter encapsulates the
+// FLUTE packet inside an inner IPv4+UDP packet, the tunnel bridge detunnels it,
+// and the receiver still reconstructs the original file correctly.
 TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel)
 {
     EndToEndOptions options;

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/asio.hpp>
 
-#include <arpa/inet.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
 #include <sys/socket.h>
@@ -29,7 +28,6 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
-#include <cstdint>
 #include <cstring>
 #include <future>
 #include <iostream>
@@ -43,382 +41,441 @@
 #include "Receiver.h"
 #include "Transmitter.h"
 
-namespace {
+namespace
+{
+    using namespace std::chrono_literals;
 
-using namespace std::chrono_literals;
+    constexpr short kPort = 18091;
+    constexpr short kTunnelPort = 18092;
+    constexpr uint64_t kTsi = 4242;
+    constexpr unsigned short kMtu = 1400;
+    constexpr size_t kTunnelPayloadLimit = kMtu - 20 - 8;
+    const std::string tunnel_address = "127.0.0.1";
+    const std::string receiver_interface = "0.0.0.0";
+    const std::string receiver_transmitter_address = "239.255.0.1";
 
-constexpr short kPort = 18091;
-constexpr short kTunnelPort = 18092;
-constexpr uint64_t kTsi = 4242;
-constexpr unsigned short kMtu = 1400;
-constexpr size_t kTunnelPayloadLimit = kMtu - 20 - 8;
+    struct TunnelBridgeStats
+    {
+        size_t received_packet_count = 0;
+        size_t forwarded_packet_count = 0;
+        size_t max_tunnel_payload_size = 0;
+        std::string error;
+    };
 
-struct TunnelBridgeStats {
-  size_t received_packet_count = 0;
-  size_t forwarded_packet_count = 0;
-  size_t max_tunnel_payload_size = 0;
-  std::string error;
-};
+    struct TunnelRuntime
+    {
+        std::atomic<bool> stop_requested = false;
+        TunnelBridgeStats stats;
+        std::thread thread;
+        std::optional<boost::asio::ip::udp::endpoint> endpoint = std::nullopt;
+    };
 
-struct TunnelRuntime {
-  std::atomic<bool> stop_requested = false;
-  TunnelBridgeStats stats;
-  std::thread thread;
-  std::optional<boost::asio::ip::udp::endpoint> endpoint = std::nullopt;
-};
+    struct EndToEndOptions
+    {
+        bool tunneled = false;
+        std::string expected_location;
+    };
 
-struct EndToEndOptions {
-  bool tunneled = false;
-  std::string expected_location;
-};
-
-auto make_test_payload() -> std::vector<char> {
-  std::vector<char> payload(5000);
-  for (size_t i = 0; i < payload.size(); ++i) {
-    payload[i] = static_cast<char>('A' + (i % 26));
-  }
-  return payload;
-}
-
-auto calculate_checksum_host_order(const uint8_t* data, size_t length) -> uint16_t {
-  uint32_t checksum = 0;
-
-  for (size_t i = 0; i + 1 < length; i += 2) {
-    checksum += (static_cast<uint32_t>(data[i]) << 8) | static_cast<uint32_t>(data[i + 1]);
-  }
-  if ((length % 2) != 0) {
-    checksum += static_cast<uint32_t>(data[length - 1]) << 8;
-  }
-
-  while ((checksum >> 16U) != 0U) {
-    checksum = (checksum & 0xFFFFU) + (checksum >> 16U);
-  }
-
-  return static_cast<uint16_t>(~checksum & 0xFFFFU);
-}
-
-auto calculate_ipv4_header_checksum(const iphdr& header, size_t header_length) -> uint16_t {
-  std::vector<uint8_t> bytes(header_length);
-  std::memcpy(bytes.data(), &header, header_length);
-
-  auto* header_copy = reinterpret_cast<iphdr*>(bytes.data());
-  header_copy->check = 0;
-
-  return calculate_checksum_host_order(bytes.data(), bytes.size());
-}
-
-auto calculate_udp_checksum(const iphdr& ip_header, const udphdr& udp_header, const uint8_t* payload,
-                            size_t payload_length) -> uint16_t {
-  const size_t udp_length = sizeof(udphdr) + payload_length;
-  std::vector<uint8_t> bytes(12 + udp_length);
-
-  std::memcpy(bytes.data(), &ip_header.saddr, sizeof(ip_header.saddr));
-  std::memcpy(bytes.data() + 4, &ip_header.daddr, sizeof(ip_header.daddr));
-  bytes[8] = 0;
-  bytes[9] = static_cast<uint8_t>(ip_header.protocol);
-  bytes[10] = static_cast<uint8_t>((udp_length >> 8) & 0xFFU);
-  bytes[11] = static_cast<uint8_t>(udp_length & 0xFFU);
-
-  std::memcpy(bytes.data() + 12, &udp_header, sizeof(udphdr));
-  auto* udp_header_copy = reinterpret_cast<udphdr*>(bytes.data() + 12);
-  udp_header_copy->uh_sum = 0;
-  std::memcpy(bytes.data() + 12 + sizeof(udphdr), payload, payload_length);
-
-  return calculate_checksum_host_order(bytes.data(), bytes.size());
-}
-
-auto set_socket_timeout(int socket_fd, std::chrono::milliseconds timeout) -> void {
-  timeval socket_timeout{};
-  socket_timeout.tv_sec = static_cast<time_t>(timeout.count() / 1000);
-  socket_timeout.tv_usec = static_cast<suseconds_t>((timeout.count() % 1000) * 1000);
-  if (setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &socket_timeout, sizeof(socket_timeout)) != 0) {
-    throw std::runtime_error("Failed to set tunnel bridge socket timeout");
-  }
-}
-
-auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
-                       TunnelBridgeStats& stats) -> void {
-  int receive_socket = -1;
-  int forward_socket = -1;
-
-  try {
-    receive_socket = socket(AF_INET, SOCK_DGRAM, 0);
-    forward_socket = socket(AF_INET, SOCK_DGRAM, 0);
-    if (receive_socket < 0 || forward_socket < 0) {
-      throw std::runtime_error("Failed to open tunnel bridge sockets");
-    }
-
-    const int reuse = 1;
-    if (setsockopt(receive_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
-      throw std::runtime_error("Failed to set tunnel bridge socket reuse");
-    }
-
-    sockaddr_in receive_address{};
-    receive_address.sin_family = AF_INET;
-    receive_address.sin_port = htons(kTunnelPort);
-    receive_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    if (bind(receive_socket, reinterpret_cast<const sockaddr*>(&receive_address), sizeof(receive_address)) != 0) {
-      throw std::runtime_error("Failed to bind tunnel bridge socket");
-    }
-
-    set_socket_timeout(receive_socket, 200ms);
-    ready_promise.set_value();
-
-    sockaddr_in forward_address{};
-    forward_address.sin_family = AF_INET;
-    forward_address.sin_port = htons(kPort);
-    forward_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-
-    const uint32_t expected_destination =
-        htonl(boost::asio::ip::make_address_v4("239.255.0.1").to_uint());
-    std::vector<uint8_t> buffer(2048);
-
-    while (!stop_requested.load()) {
-      sockaddr_in sender_address{};
-      socklen_t sender_length = sizeof(sender_address);
-      const ssize_t received_bytes = recvfrom(receive_socket,
-                                              buffer.data(),
-                                              buffer.size(),
-                                              0,
-                                              reinterpret_cast<sockaddr*>(&sender_address),
-                                              &sender_length);
-      if (received_bytes < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
-          continue;
+    auto make_test_payload() -> std::vector<char>
+    {
+        std::vector<char> payload(5000);
+        for (size_t i = 0; i < payload.size(); ++i)
+        {
+            payload[i] = static_cast<char>('A' + (i % 26));
         }
-        throw std::runtime_error("Tunnel bridge failed to receive packet");
-      }
-
-      const size_t packet_size = static_cast<size_t>(received_bytes);
-      stats.received_packet_count += 1;
-      stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
-
-      if (packet_size > kTunnelPayloadLimit) {
-        throw std::runtime_error("Tunnelled packet exceeded MTU-safe payload size");
-      }
-      if (packet_size < sizeof(iphdr) + sizeof(udphdr)) {
-        throw std::runtime_error("Tunnelled packet too short for inner IP/UDP headers");
-      }
-
-      const auto* ip_header = reinterpret_cast<const iphdr*>(buffer.data());
-      const size_t ip_header_length = static_cast<size_t>(ip_header->ihl) * 4U;
-      if (ip_header->version != 4 || ip_header_length < sizeof(iphdr)) {
-        throw std::runtime_error("Tunnelled packet contained invalid inner IPv4 header");
-      }
-      if (packet_size < ip_header_length + sizeof(udphdr)) {
-        throw std::runtime_error("Tunnelled packet shorter than declared inner IP header");
-      }
-      if (ntohs(ip_header->tot_len) != packet_size) {
-        throw std::runtime_error("Tunnelled packet inner IPv4 total length mismatch");
-      }
-      if (ip_header->protocol != IPPROTO_UDP) {
-        throw std::runtime_error("Tunnelled packet inner protocol was not UDP");
-      }
-      if (ip_header->daddr != expected_destination) {
-        throw std::runtime_error("Tunnelled packet inner IPv4 destination mismatch");
-      }
-      if (calculate_ipv4_header_checksum(*ip_header, ip_header_length) != ntohs(ip_header->check)) {
-        throw std::runtime_error("Tunnelled packet inner IPv4 checksum mismatch");
-      }
-
-      const auto* udp_header = reinterpret_cast<const udphdr*>(buffer.data() + ip_header_length);
-      const size_t udp_length = ntohs(udp_header->uh_ulen);
-      if (udp_length < sizeof(udphdr) || ip_header_length + udp_length != packet_size) {
-        throw std::runtime_error("Tunnelled packet inner UDP length mismatch");
-      }
-      if (ntohs(udp_header->uh_sport) != kPort || ntohs(udp_header->uh_dport) != kPort) {
-        throw std::runtime_error("Tunnelled packet inner UDP ports mismatch");
-      }
-      if (udp_header->uh_sum == 0) {
-        throw std::runtime_error("Tunnelled packet inner UDP checksum missing");
-      }
-
-      const size_t flute_payload_size = udp_length - sizeof(udphdr);
-      const auto* flute_payload = buffer.data() + ip_header_length + sizeof(udphdr);
-      if (calculate_udp_checksum(*ip_header, *udp_header, flute_payload, flute_payload_size) !=
-          ntohs(udp_header->uh_sum)) {
-        throw std::runtime_error("Tunnelled packet inner UDP checksum mismatch");
-      }
-
-      const ssize_t forwarded_bytes = sendto(forward_socket,
-                                             flute_payload,
-                                             flute_payload_size,
-                                             0,
-                                             reinterpret_cast<const sockaddr*>(&forward_address),
-                                             sizeof(forward_address));
-      if (forwarded_bytes != static_cast<ssize_t>(flute_payload_size)) {
-        throw std::runtime_error("Tunnel bridge failed to forward FLUTE payload");
-      }
-
-      stats.forwarded_packet_count += 1;
+        return payload;
     }
-  } catch (const std::exception& ex) {
-    if (stats.error.empty()) {
-      stats.error = ex.what();
+
+    auto calculate_checksum_host_order(const uint8_t* data, size_t length) -> uint16_t
+    {
+        uint32_t checksum = 0;
+
+        for (size_t i = 0; i + 1 < length; i += 2)
+        {
+            checksum += (static_cast<uint32_t>(data[i]) << 8) | static_cast<uint32_t>(data[i + 1]);
+        }
+        if ((length % 2) != 0)
+        {
+            checksum += static_cast<uint32_t>(data[length - 1]) << 8;
+        }
+
+        while ((checksum >> 16U) != 0U)
+        {
+            checksum = (checksum & 0xFFFFU) + (checksum >> 16U);
+        }
+
+        return static_cast<uint16_t>(~checksum & 0xFFFFU);
     }
-    stop_requested.store(true);
-    try {
-      ready_promise.set_value();
-    } catch (const std::future_error&) {
+
+    auto calculate_ipv4_header_checksum(const iphdr& header, size_t header_length) -> uint16_t
+    {
+        std::vector<uint8_t> bytes(header_length);
+        std::memcpy(bytes.data(), &header, header_length);
+
+        auto* header_copy = reinterpret_cast<iphdr*>(bytes.data());
+        header_copy->check = 0;
+
+        return calculate_checksum_host_order(bytes.data(), bytes.size());
     }
-  }
 
-  if (receive_socket >= 0) {
-    close(receive_socket);
-  }
-  if (forward_socket >= 0) {
-    close(forward_socket);
-  }
-}
+    auto calculate_udp_checksum(const iphdr& ip_header, const udphdr& udp_header, const uint8_t* payload,
+                                size_t payload_length) -> uint16_t
+    {
+        const size_t udp_length = sizeof(udphdr) + payload_length;
+        std::vector<uint8_t> bytes(12 + udp_length);
 
-auto start_tunnel_bridge(TunnelRuntime& tunnel_runtime) -> void {
-  std::future<void> tunnel_ready_future;
-  std::promise<void> tunnel_ready_promise;
-  tunnel_ready_future = tunnel_ready_promise.get_future();
-  tunnel_runtime.endpoint =
-      boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), kTunnelPort);
-  tunnel_runtime.thread =
-      std::thread([ready_promise = std::move(tunnel_ready_promise), &tunnel_runtime]() mutable {
-        run_tunnel_bridge(std::move(ready_promise), tunnel_runtime.stop_requested, tunnel_runtime.stats);
-      });
+        std::memcpy(bytes.data(), &ip_header.saddr, sizeof(ip_header.saddr));
+        std::memcpy(bytes.data() + 4, &ip_header.daddr, sizeof(ip_header.daddr));
+        bytes[8] = 0;
+        bytes[9] = static_cast<uint8_t>(ip_header.protocol);
+        bytes[10] = static_cast<uint8_t>((udp_length >> 8) & 0xFFU);
+        bytes[11] = static_cast<uint8_t>(udp_length & 0xFFU);
 
-  const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
-  if (tunnel_ready != std::future_status::ready) {
-    tunnel_runtime.stop_requested.store(true);
-    if (tunnel_runtime.thread.joinable()) {
-      tunnel_runtime.thread.join();
+        std::memcpy(bytes.data() + 12, &udp_header, sizeof(udphdr));
+        auto* udp_header_copy = reinterpret_cast<udphdr*>(bytes.data() + 12);
+        udp_header_copy->uh_sum = 0;
+        std::memcpy(bytes.data() + 12 + sizeof(udphdr), payload, payload_length);
+
+        return calculate_checksum_host_order(bytes.data(), bytes.size());
     }
-    FAIL() << "Timed out waiting for tunnel bridge to start";
-  }
 
-  ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
-}
+    auto set_socket_timeout(int socket_fd, std::chrono::milliseconds timeout) -> void
+    {
+        timeval socket_timeout{};
+        socket_timeout.tv_sec = static_cast<time_t>(timeout.count() / 1000);
+        socket_timeout.tv_usec = static_cast<suseconds_t>((timeout.count() % 1000) * 1000);
+        if (setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &socket_timeout, sizeof(socket_timeout)) != 0)
+        {
+            throw std::runtime_error("Failed to set tunnel bridge socket timeout");
+        }
+    }
 
-auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
-  const std::string expected_location = options.expected_location;
-  const std::vector<char> expected_payload = make_test_payload();
-  const auto now = std::chrono::system_clock::now();
+    auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
+                           TunnelBridgeStats& stats) -> void
+    {
+        int receive_socket = -1;
+        int forward_socket = -1;
 
-  ASSERT_FALSE(expected_payload.empty());
+        try
+        {
+            receive_socket = socket(AF_INET, SOCK_DGRAM, 0);
+            forward_socket = socket(AF_INET, SOCK_DGRAM, 0);
+            if (receive_socket < 0 || forward_socket < 0)
+            {
+                throw std::runtime_error("Failed to open tunnel bridge sockets");
+            }
 
-  TunnelRuntime tunnel_runtime;
-  if (options.tunneled) {
-    start_tunnel_bridge(tunnel_runtime);
-  }
+            constexpr int reuse = 1;
+            if (setsockopt(receive_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0)
+            {
+                throw std::runtime_error("Failed to set tunnel bridge socket reuse");
+            }
 
-  boost::asio::io_context receiver_io;
-  boost::asio::io_context transmitter_io;
+            sockaddr_in receive_address{};
+            receive_address.sin_family = AF_INET;
+            receive_address.sin_port = htons(kTunnelPort);
+            receive_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            if (bind(receive_socket, reinterpret_cast<const sockaddr*>(&receive_address), sizeof(receive_address)) != 0)
+            {
+                throw std::runtime_error("Failed to bind tunnel bridge socket");
+            }
 
-  LibFlute::Receiver receiver("0.0.0.0", "239.255.0.1", kPort, kTsi, receiver_io);
-  LibFlute::Transmitter transmitter(
-      "239.255.0.1",
-      kPort,
-      kTsi,
-      kMtu,
-      0,
-      transmitter_io,
-      tunnel_runtime.endpoint,
-      LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+            set_socket_timeout(receive_socket, 200ms);
+            ready_promise.set_value();
 
-  auto file_description = std::make_shared<LibFlute::Transmitter::FileDescription>(
-      expected_location,
-      expected_payload);
-  file_description->set_content_type("application/octet-stream");
-  file_description->set_expiry_time(now + 60s);
+            sockaddr_in forward_address{};
+            forward_address.sin_family = AF_INET;
+            forward_address.sin_port = htons(kPort);
+            forward_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
-  std::promise<std::shared_ptr<LibFlute::File>> received_file_promise;
-  std::promise<uint32_t> transmitted_toi_promise;
-  auto received_file_future = received_file_promise.get_future();
-  auto transmitted_toi_future = transmitted_toi_promise.get_future();
+            const uint32_t expected_destination =
+                htonl(boost::asio::ip::make_address_v4("239.255.0.1").to_uint());
+            std::vector<uint8_t> buffer(2048);
 
-  receiver.register_completion_callback(
-      [&received_file_promise, &receiver, &receiver_io](const std::shared_ptr<LibFlute::File>& file) {
-        std::cout << "Received file TOI " << file->meta().toi
-                  << " location '" << file->meta().content_location << "'"
-                  << " with " << file->length() << " bytes" << std::endl;
-        received_file_promise.set_value(file);
-        receiver.stop();
-        receiver_io.stop();
-      });
+            while (!stop_requested.load())
+            {
+                sockaddr_in sender_address{};
+                socklen_t sender_length = sizeof(sender_address);
+                const ssize_t received_bytes = recvfrom(receive_socket,
+                                                        buffer.data(),
+                                                        buffer.size(),
+                                                        0,
+                                                        reinterpret_cast<sockaddr*>(&sender_address),
+                                                        &sender_length);
+                if (received_bytes < 0)
+                {
+                    if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+                    {
+                        continue;
+                    }
+                    throw std::runtime_error("Tunnel bridge failed to receive packet");
+                }
 
-  transmitter.register_completion_callback(
-      [&transmitted_toi_promise, &transmitter, &transmitter_io](const uint32_t toi) {
-        std::cout << "Transmitted file TOI " << toi << std::endl;
-        transmitted_toi_promise.set_value(toi);
-        transmitter.deactivate();
-        transmitter_io.stop();
-      });
+                const auto packet_size = static_cast<size_t>(received_bytes);
+                stats.received_packet_count += 1;
+                stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
 
-  std::thread receiver_thread([&receiver_io]() { receiver_io.run(); });
-  std::thread transmitter_thread([&transmitter_io]() { transmitter_io.run(); });
+                if (packet_size > kTunnelPayloadLimit)
+                {
+                    throw std::runtime_error("Tunnelled packet exceeded MTU-safe payload size");
+                }
+                if (packet_size < sizeof(iphdr) + sizeof(udphdr))
+                {
+                    throw std::runtime_error("Tunnelled packet too short for inner IP/UDP headers");
+                }
 
-  std::cout << "Sending payload as '" << expected_location << "' with " << expected_payload.size()
+                const auto* ip_header = reinterpret_cast<const iphdr*>(buffer.data());
+                const size_t ip_header_length = static_cast<size_t>(ip_header->ihl) * 4U;
+                if (ip_header->version != 4 || ip_header_length < sizeof(iphdr))
+                {
+                    throw std::runtime_error("Tunnelled packet contained invalid inner IPv4 header");
+                }
+                if (packet_size < ip_header_length + sizeof(udphdr))
+                {
+                    throw std::runtime_error("Tunnelled packet shorter than declared inner IP header");
+                }
+                if (ntohs(ip_header->tot_len) != packet_size)
+                {
+                    throw std::runtime_error("Tunnelled packet inner IPv4 total length mismatch");
+                }
+                if (ip_header->protocol != IPPROTO_UDP)
+                {
+                    throw std::runtime_error("Tunnelled packet inner protocol was not UDP");
+                }
+                if (ip_header->daddr != expected_destination)
+                {
+                    throw std::runtime_error("Tunnelled packet inner IPv4 destination mismatch");
+                }
+                if (calculate_ipv4_header_checksum(*ip_header, ip_header_length) != ntohs(ip_header->check))
+                {
+                    throw std::runtime_error("Tunnelled packet inner IPv4 checksum mismatch");
+                }
+
+                const auto* udp_header = reinterpret_cast<const udphdr*>(buffer.data() + ip_header_length);
+                const size_t udp_length = ntohs(udp_header->uh_ulen);
+                if (udp_length < sizeof(udphdr) || ip_header_length + udp_length != packet_size)
+                {
+                    throw std::runtime_error("Tunnelled packet inner UDP length mismatch");
+                }
+                if (ntohs(udp_header->uh_sport) != kPort || ntohs(udp_header->uh_dport) != kPort)
+                {
+                    throw std::runtime_error("Tunnelled packet inner UDP ports mismatch");
+                }
+                if (udp_header->uh_sum == 0)
+                {
+                    throw std::runtime_error("Tunnelled packet inner UDP checksum missing");
+                }
+
+                const size_t flute_payload_size = udp_length - sizeof(udphdr);
+                const auto* flute_payload = buffer.data() + ip_header_length + sizeof(udphdr);
+                if (calculate_udp_checksum(*ip_header, *udp_header, flute_payload, flute_payload_size) !=
+                    ntohs(udp_header->uh_sum))
+                {
+                    throw std::runtime_error("Tunnelled packet inner UDP checksum mismatch");
+                }
+
+                const ssize_t forwarded_bytes = sendto(forward_socket,
+                                                       flute_payload,
+                                                       flute_payload_size,
+                                                       0,
+                                                       reinterpret_cast<const sockaddr*>(&forward_address),
+                                                       sizeof(forward_address));
+                if (forwarded_bytes != static_cast<ssize_t>(flute_payload_size))
+                {
+                    throw std::runtime_error("Tunnel bridge failed to forward FLUTE payload");
+                }
+
+                stats.forwarded_packet_count += 1;
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            if (stats.error.empty())
+            {
+                stats.error = ex.what();
+            }
+            stop_requested.store(true);
+            try
+            {
+                ready_promise.set_value();
+            }
+            catch (const std::future_error&)
+            {
+            }
+        }
+
+        if (receive_socket >= 0)
+        {
+            close(receive_socket);
+        }
+        if (forward_socket >= 0)
+        {
+            close(forward_socket);
+        }
+    }
+
+    auto start_tunnel_bridge(TunnelRuntime& tunnel_runtime) -> void
+    {
+        std::promise<void> tunnel_ready_promise;
+        std::future<void> tunnel_ready_future = tunnel_ready_promise.get_future();
+        tunnel_runtime.endpoint =
+            boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(tunnel_address), kTunnelPort);
+        tunnel_runtime.thread =
+            std::thread([ready_promise = std::move(tunnel_ready_promise), &tunnel_runtime]() mutable
+            {
+                run_tunnel_bridge(std::move(ready_promise), tunnel_runtime.stop_requested, tunnel_runtime.stats);
+            });
+
+        const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
+        if (tunnel_ready != std::future_status::ready)
+        {
+            tunnel_runtime.stop_requested.store(true);
+            if (tunnel_runtime.thread.joinable())
+            {
+                tunnel_runtime.thread.join();
+            }
+            FAIL() << "Timed out waiting for tunnel bridge to start";
+        }
+
+        ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+    }
+
+    auto run_end_to_end_scenario(const EndToEndOptions& options) -> void
+    {
+        const std::string expected_location = options.expected_location;
+        const std::vector<char> expected_payload = make_test_payload();
+        const auto now = std::chrono::system_clock::now();
+
+        ASSERT_FALSE(expected_payload.empty());
+
+        TunnelRuntime tunnel_runtime;
+        if (options.tunneled)
+        {
+            start_tunnel_bridge(tunnel_runtime);
+        }
+
+        boost::asio::io_context receiver_io;
+        boost::asio::io_context transmitter_io;
+
+        LibFlute::Receiver receiver(receiver_interface, receiver_transmitter_address, kPort, kTsi, receiver_io);
+        LibFlute::Transmitter transmitter(
+            receiver_transmitter_address,
+            kPort,
+            kTsi,
+            kMtu,
+            0,
+            transmitter_io,
+            tunnel_runtime.endpoint,
+            LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+
+        auto file_description = std::make_shared<LibFlute::Transmitter::FileDescription>(
+            expected_location,
+            expected_payload);
+        file_description->set_content_type("application/octet-stream");
+        file_description->set_expiry_time(now + 60s);
+
+        std::promise<std::shared_ptr<LibFlute::File>> received_file_promise;
+        std::promise<uint32_t> transmitted_toi_promise;
+        auto received_file_future = received_file_promise.get_future();
+        auto transmitted_toi_future = transmitted_toi_promise.get_future();
+
+        receiver.register_completion_callback(
+            [&received_file_promise, &receiver, &receiver_io](const std::shared_ptr<LibFlute::File>& file)
+            {
+                std::cout << "Received file TOI " << file->meta().toi
+                    << " location '" << file->meta().content_location << "'"
+                    << " with " << file->length() << " bytes" << std::endl;
+                received_file_promise.set_value(file);
+                receiver.stop();
+                receiver_io.stop();
+            });
+
+        transmitter.register_completion_callback(
+            [&transmitted_toi_promise, &transmitter, &transmitter_io](const uint32_t toi)
+            {
+                std::cout << "Transmitted file TOI " << toi << std::endl;
+                transmitted_toi_promise.set_value(toi);
+                transmitter.deactivate();
+                transmitter_io.stop();
+            });
+
+        std::thread receiver_thread([&receiver_io]() { receiver_io.run(); });
+        std::thread transmitter_thread([&transmitter_io]() { transmitter_io.run(); });
+
+        std::cout << "Sending payload as '" << expected_location << "' with " << expected_payload.size()
             << " bytes" << (options.tunneled ? " through UDP tunnel" : "") << std::endl;
-  transmitter.send(file_description);
+        transmitter.send(file_description);
 
-  const auto transmitted_ready = transmitted_toi_future.wait_for(5s);
-  const auto received_ready = received_file_future.wait_for(5s);
+        const auto transmitted_ready = transmitted_toi_future.wait_for(5s);
+        const auto received_ready = received_file_future.wait_for(5s);
 
-  if (transmitted_ready != std::future_status::ready || received_ready != std::future_status::ready) {
-    std::cerr << "Timed out waiting for end-to-end completion. transmitted_ready="
-              << (transmitted_ready == std::future_status::ready)
-              << ", received_ready=" << (received_ready == std::future_status::ready) << std::endl;
-    transmitter.deactivate();
-    transmitter_io.stop();
-    receiver.stop();
-    receiver_io.stop();
-  }
+        if (transmitted_ready != std::future_status::ready || received_ready != std::future_status::ready)
+        {
+            std::cerr << "Timed out waiting for end-to-end completion. transmitted_ready="
+                << (transmitted_ready == std::future_status::ready)
+                << ", received_ready=" << (received_ready == std::future_status::ready) << std::endl;
+            transmitter.deactivate();
+            transmitter_io.stop();
+            receiver.stop();
+            receiver_io.stop();
+        }
 
-  if (receiver_thread.joinable()) {
-    receiver_thread.join();
-  }
-  if (transmitter_thread.joinable()) {
-    transmitter_thread.join();
-  }
+        if (receiver_thread.joinable())
+        {
+            receiver_thread.join();
+        }
+        if (transmitter_thread.joinable())
+        {
+            transmitter_thread.join();
+        }
 
-  if (options.tunneled) {
-    tunnel_runtime.stop_requested.store(true);
-    if (tunnel_runtime.thread.joinable()) {
-      tunnel_runtime.thread.join();
+        if (options.tunneled)
+        {
+            tunnel_runtime.stop_requested.store(true);
+            if (tunnel_runtime.thread.joinable())
+            {
+                tunnel_runtime.thread.join();
+            }
+        }
+
+        ASSERT_EQ(transmitted_ready, std::future_status::ready);
+        ASSERT_EQ(received_ready, std::future_status::ready);
+
+        const auto transmitted_toi = transmitted_toi_future.get();
+        const auto received_file = received_file_future.get();
+        ASSERT_NE(received_file, nullptr);
+
+        EXPECT_EQ(transmitted_toi, file_description->toi());
+        EXPECT_EQ(received_file->meta().toi, transmitted_toi);
+        EXPECT_EQ(received_file->meta().content_location, expected_location);
+        EXPECT_EQ(received_file->meta().content_length, expected_payload.size());
+
+        const std::string expected_payload_string(expected_payload.begin(), expected_payload.end());
+        const std::string received_payload(received_file->buffer(), received_file->length());
+        EXPECT_EQ(received_payload, expected_payload_string);
+
+        if (options.tunneled)
+        {
+            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+            EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
+            EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
+            EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, kTunnelPayloadLimit);
+        }
     }
-  }
+} // namespace
 
-  ASSERT_EQ(transmitted_ready, std::future_status::ready);
-  ASSERT_EQ(received_ready, std::future_status::ready);
-
-  const auto transmitted_toi = transmitted_toi_future.get();
-  const auto received_file = received_file_future.get();
-  ASSERT_NE(received_file, nullptr);
-
-  EXPECT_EQ(transmitted_toi, file_description->toi());
-  EXPECT_EQ(received_file->meta().toi, transmitted_toi);
-  EXPECT_EQ(received_file->meta().content_location, expected_location);
-  EXPECT_EQ(received_file->meta().content_length, expected_payload.size());
-
-  const std::string expected_payload_string(expected_payload.begin(), expected_payload.end());
-  const std::string received_payload(received_file->buffer(), received_file->length());
-  EXPECT_EQ(received_payload, expected_payload_string);
-
-  if (options.tunneled) {
-    ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
-    EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
-    EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
-    EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, kTunnelPayloadLimit);
-  }
+TEST(FluteEndToEndTest, TransmitsFileToReceiver)
+{
+    EndToEndOptions options;
+    options.tunneled = false;
+    options.expected_location = "e2e/payload.bin";
+    run_end_to_end_scenario(options);
 }
 
-}  // namespace
-
-TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
-  EndToEndOptions options;
-  options.tunneled = false;
-  options.expected_location = "e2e/payload.bin";
-  run_end_to_end_scenario(options);
-}
-
-TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel) {
-  EndToEndOptions options;
-  options.tunneled = true;
-  options.expected_location = "e2e/tunnelled-payload.bin";
-  run_end_to_end_scenario(options);
+TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel)
+{
+    EndToEndOptions options;
+    options.tunneled = true;
+    options.expected_location = "e2e/tunnelled-payload.bin";
+    run_end_to_end_scenario(options);
 }

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -45,14 +45,14 @@ namespace
 {
     using namespace std::chrono_literals;
 
-    constexpr short kPort = 18091;
-    constexpr short kTunnelPort = 18092;
-    constexpr uint64_t kTsi = 4242;
-    constexpr unsigned short kMtu = 1400;
-    constexpr size_t kTunnelPayloadLimit = kMtu - 20 - 8;
+    constexpr short port = 18091;
+    constexpr short tunnel_port = 18092;
+    constexpr uint64_t tsi = 4242;
+    constexpr unsigned short mtu = 1400;
+    constexpr size_t tunnel_payload_limit = mtu - 20 - 8;
     const std::string tunnel_address = "127.0.0.1";
     const std::string receiver_interface = "0.0.0.0";
-    const std::string receiver_transmitter_address = "239.255.0.1";
+    const std::string multicast_address = "239.255.0.1";
 
     struct TunnelBridgeStats
     {
@@ -76,7 +76,9 @@ namespace
         std::string expected_location;
     };
 
-    auto make_test_payload() -> std::vector<char>
+    // Builds a deterministic 5,000-byte payload with a repeating A-Z pattern so
+    // both end-to-end scenarios can assert exact file contents after delivery.
+    auto create_test_payload() -> std::vector<char>
     {
         std::vector<char> payload(5000);
         for (size_t i = 0; i < payload.size(); ++i)
@@ -152,7 +154,7 @@ namespace
 
     // In tunneled mode the transmitter sends an outer UDP datagram whose payload is
     // a complete inner IPv4+UDP packet carrying the FLUTE payload. This helper
-    // detunnels that packet and forwards only the inner FLUTE bytes to the regular
+    // de-tunnels that packet and forwards only the inner FLUTE bytes to the regular
     // receiver path used by this end-to-end test.
     auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
                            TunnelBridgeStats& stats) -> void
@@ -177,7 +179,7 @@ namespace
 
             sockaddr_in receive_address{};
             receive_address.sin_family = AF_INET;
-            receive_address.sin_port = htons(kTunnelPort);
+            receive_address.sin_port = htons(tunnel_port);
             receive_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
             if (bind(receive_socket, reinterpret_cast<const sockaddr*>(&receive_address), sizeof(receive_address)) != 0)
             {
@@ -189,11 +191,11 @@ namespace
 
             sockaddr_in forward_address{};
             forward_address.sin_family = AF_INET;
-            forward_address.sin_port = htons(kPort);
+            forward_address.sin_port = htons(port);
             forward_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
             const uint32_t expected_destination =
-                htonl(boost::asio::ip::make_address_v4("239.255.0.1").to_uint());
+                htonl(boost::asio::ip::make_address_v4(multicast_address).to_uint());
             std::vector<uint8_t> buffer(2048);
 
             while (!stop_requested.load())
@@ -219,7 +221,7 @@ namespace
                 stats.received_packet_count += 1;
                 stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
 
-                if (packet_size > kTunnelPayloadLimit)
+                if (packet_size > tunnel_payload_limit)
                 {
                     throw std::runtime_error("Tunnelled packet exceeded MTU-safe payload size");
                 }
@@ -263,7 +265,7 @@ namespace
                 {
                     throw std::runtime_error("Tunnelled packet inner UDP length mismatch");
                 }
-                if (ntohs(udp_header->uh_sport) != kPort || ntohs(udp_header->uh_dport) != kPort)
+                if (ntohs(udp_header->uh_sport) != port || ntohs(udp_header->uh_dport) != port)
                 {
                     throw std::runtime_error("Tunnelled packet inner UDP ports mismatch");
                 }
@@ -322,12 +324,15 @@ namespace
         }
     }
 
+    // Starts the tunnel bridge thread for tunneled end-to-end tests, records the
+    // tunnel endpoint for the transmitter, and waits until the bridge is ready or
+    // reports an immediate startup failure before the test continues.
     auto start_tunnel_bridge(TunnelRuntime& tunnel_runtime) -> void
     {
         std::promise<void> tunnel_ready_promise;
         std::future<void> tunnel_ready_future = tunnel_ready_promise.get_future();
         tunnel_runtime.endpoint =
-            boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(tunnel_address), kTunnelPort);
+            boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(tunnel_address), tunnel_port);
         tunnel_runtime.thread =
             std::thread([ready_promise = std::move(tunnel_ready_promise), &tunnel_runtime]() mutable
             {
@@ -351,7 +356,7 @@ namespace
     auto run_end_to_end_scenario(const EndToEndOptions& options) -> void
     {
         const std::string expected_location = options.expected_location;
-        const std::vector<char> expected_payload = make_test_payload();
+        const std::vector<char> expected_payload = create_test_payload();
         const auto now = std::chrono::system_clock::now();
 
         ASSERT_FALSE(expected_payload.empty());
@@ -368,12 +373,12 @@ namespace
         boost::asio::io_context receiver_io;
         boost::asio::io_context transmitter_io;
 
-        LibFlute::Receiver receiver(receiver_interface, receiver_transmitter_address, kPort, kTsi, receiver_io);
+        LibFlute::Receiver receiver(receiver_interface, multicast_address, port, tsi, receiver_io);
         LibFlute::Transmitter transmitter(
-            receiver_transmitter_address,
-            kPort,
-            kTsi,
-            kMtu,
+            multicast_address,
+            port,
+            tsi,
+            mtu,
             0,
             transmitter_io,
             tunnel_runtime.endpoint,
@@ -472,7 +477,7 @@ namespace
             ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
             EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
             EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
-            EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, kTunnelPayloadLimit);
+            EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, tunnel_payload_limit);
         }
     }
 } // namespace
@@ -490,7 +495,7 @@ TEST(FluteEndToEndTest, TransmitsFileToReceiver)
 }
 
 // Verifies tunneled transmission end to end: the transmitter encapsulates the
-// FLUTE packet inside an inner IPv4+UDP packet, the tunnel bridge detunnels it,
+// FLUTE packet inside an inner IPv4+UDP packet, the tunnel bridge de-tunnels it,
 // and the receiver still reconstructs the original file correctly.
 TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel)
 {

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -62,6 +62,7 @@ struct TunnelBridgeStats {
 
 struct EndToEndOptions {
   bool tunneled = false;
+  std::string expected_location;
 };
 
 auto make_test_payload() -> std::vector<char> {
@@ -264,20 +265,20 @@ auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop
 }
 
 auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
-  const std::string expected_location = options.tunneled ? "e2e/tunnelled-payload.bin" : "e2e/payload.bin";
+  const std::string expected_location = options.expected_location;
   const std::vector<char> expected_payload = make_test_payload();
   const auto now = std::chrono::system_clock::now();
 
   ASSERT_FALSE(expected_payload.empty());
 
-  std::promise<void> tunnel_ready_promise;
-  std::future<void> tunnel_ready_future;
   std::atomic<bool> tunnel_stop_requested = false;
   TunnelBridgeStats tunnel_stats;
   std::thread tunnel_thread;
 
   std::optional<boost::asio::ip::udp::endpoint> tunnel_endpoint = std::nullopt;
   if (options.tunneled) {
+    std::future<void> tunnel_ready_future;
+    std::promise<void> tunnel_ready_promise;
     tunnel_ready_future = tunnel_ready_promise.get_future();
     tunnel_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), kTunnelPort);
     tunnel_thread = std::thread(
@@ -401,11 +402,13 @@ auto run_end_to_end_scenario(const EndToEndOptions& options) -> void {
 TEST(FluteEndToEndTest, TransmitsFileToReceiver) {
   EndToEndOptions options;
   options.tunneled = false;
+  options.expected_location = "e2e/payload.bin";
   run_end_to_end_scenario(options);
 }
 
 TEST(FluteEndToEndTest, TransmitsFileToReceiverThroughUdpTunnel) {
   EndToEndOptions options;
   options.tunneled = true;
+  options.expected_location = "e2e/tunnelled-payload.bin";
   run_end_to_end_scenario(options);
 }

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -430,6 +430,13 @@ namespace
             std::cerr << "Timed out waiting for end-to-end completion. transmitted_ready="
                 << (transmitted_ready == std::future_status::ready)
                 << ", received_ready=" << (received_ready == std::future_status::ready) << std::endl;
+            if (options.tunneled)
+            {
+                std::cerr << "Tunnel bridge stats: error='" << tunnel_runtime.stats.error
+                    << "', received_packet_count=" << tunnel_runtime.stats.received_packet_count
+                    << ", forwarded_packet_count=" << tunnel_runtime.stats.forwarded_packet_count
+                    << ", max_tunnel_payload_size=" << tunnel_runtime.stats.max_tunnel_payload_size << std::endl;
+            }
             transmitter.deactivate();
             transmitter_io.stop();
             receiver.stop();
@@ -447,6 +454,7 @@ namespace
 
         if (options.tunneled)
         {
+            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
             tunnel_runtime.stop_requested.store(true);
             if (tunnel_runtime.thread.joinable())
             {

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -454,12 +454,12 @@ namespace
 
         if (options.tunneled)
         {
-            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
             tunnel_runtime.stop_requested.store(true);
             if (tunnel_runtime.thread.joinable())
             {
                 tunnel_runtime.thread.join();
             }
+            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
         }
 
         ASSERT_EQ(transmitted_ready, std::future_status::ready);

--- a/tests/test_end_to_end.cpp
+++ b/tests/test_end_to_end.cpp
@@ -32,6 +32,7 @@
 #include <future>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -65,6 +66,7 @@ namespace
     struct TunnelRuntime
     {
         std::atomic<bool> stop_requested = false;
+        std::mutex stats_mutex;
         TunnelBridgeStats stats;
         std::thread thread;
         std::optional<boost::asio::ip::udp::endpoint> endpoint = std::nullopt;
@@ -75,6 +77,12 @@ namespace
         bool tunneled = false;
         std::string expected_location;
     };
+
+    auto tunnel_bridge_stats(TunnelRuntime& tunnel_runtime) -> TunnelBridgeStats
+    {
+        const std::lock_guard<std::mutex> lock(tunnel_runtime.stats_mutex);
+        return tunnel_runtime.stats;
+    }
 
     // Builds a deterministic 5,000-byte payload with a repeating A-Z pattern so
     // both end-to-end scenarios can assert exact file contents after delivery.
@@ -157,7 +165,7 @@ namespace
     // de-tunnels that packet and forwards only the inner FLUTE bytes to the regular
     // receiver path used by this end-to-end test.
     auto run_tunnel_bridge(std::promise<void> ready_promise, std::atomic<bool>& stop_requested,
-                           TunnelBridgeStats& stats) -> void
+                           std::mutex& stats_mutex, TunnelBridgeStats& stats) -> void
     {
         int receive_socket = -1;
         int forward_socket = -1;
@@ -218,8 +226,11 @@ namespace
                 }
 
                 const auto packet_size = static_cast<size_t>(received_bytes);
-                stats.received_packet_count += 1;
-                stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
+                {
+                    const std::lock_guard<std::mutex> lock(stats_mutex);
+                    stats.received_packet_count += 1;
+                    stats.max_tunnel_payload_size = std::max(stats.max_tunnel_payload_size, packet_size);
+                }
 
                 if (packet_size > tunnel_payload_limit)
                 {
@@ -295,14 +306,20 @@ namespace
                     throw std::runtime_error("Tunnel bridge failed to forward FLUTE payload");
                 }
 
-                stats.forwarded_packet_count += 1;
+                {
+                    const std::lock_guard<std::mutex> lock(stats_mutex);
+                    stats.forwarded_packet_count += 1;
+                }
             }
         }
         catch (const std::exception& ex)
         {
-            if (stats.error.empty())
             {
-                stats.error = ex.what();
+                const std::lock_guard<std::mutex> lock(stats_mutex);
+                if (stats.error.empty())
+                {
+                    stats.error = ex.what();
+                }
             }
             stop_requested.store(true);
             try
@@ -336,7 +353,8 @@ namespace
         tunnel_runtime.thread =
             std::thread([ready_promise = std::move(tunnel_ready_promise), &tunnel_runtime]() mutable
             {
-                run_tunnel_bridge(std::move(ready_promise), tunnel_runtime.stop_requested, tunnel_runtime.stats);
+                run_tunnel_bridge(
+                    std::move(ready_promise), tunnel_runtime.stop_requested, tunnel_runtime.stats_mutex, tunnel_runtime.stats);
             });
 
         const auto tunnel_ready = tunnel_ready_future.wait_for(2s);
@@ -350,7 +368,8 @@ namespace
             FAIL() << "Timed out waiting for tunnel bridge to start";
         }
 
-        ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+        const auto stats = tunnel_bridge_stats(tunnel_runtime);
+        ASSERT_TRUE(stats.error.empty()) << stats.error;
     }
 
     auto run_end_to_end_scenario(const EndToEndOptions& options) -> void
@@ -432,10 +451,11 @@ namespace
                 << ", received_ready=" << (received_ready == std::future_status::ready) << std::endl;
             if (options.tunneled)
             {
-                std::cerr << "Tunnel bridge stats: error='" << tunnel_runtime.stats.error
-                    << "', received_packet_count=" << tunnel_runtime.stats.received_packet_count
-                    << ", forwarded_packet_count=" << tunnel_runtime.stats.forwarded_packet_count
-                    << ", max_tunnel_payload_size=" << tunnel_runtime.stats.max_tunnel_payload_size << std::endl;
+                const auto stats = tunnel_bridge_stats(tunnel_runtime);
+                std::cerr << "Tunnel bridge stats: error='" << stats.error
+                    << "', received_packet_count=" << stats.received_packet_count
+                    << ", forwarded_packet_count=" << stats.forwarded_packet_count
+                    << ", max_tunnel_payload_size=" << stats.max_tunnel_payload_size << std::endl;
             }
             transmitter.deactivate();
             transmitter_io.stop();
@@ -459,7 +479,8 @@ namespace
             {
                 tunnel_runtime.thread.join();
             }
-            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
+            const auto stats = tunnel_bridge_stats(tunnel_runtime);
+            ASSERT_TRUE(stats.error.empty()) << stats.error;
         }
 
         ASSERT_EQ(transmitted_ready, std::future_status::ready);
@@ -482,10 +503,11 @@ namespace
         {
             // Confirm that tunneled delivery really used the bridge and that the
             // encapsulated packets stayed within the configured MTU-safe payload limit.
-            ASSERT_TRUE(tunnel_runtime.stats.error.empty()) << tunnel_runtime.stats.error;
-            EXPECT_GT(tunnel_runtime.stats.received_packet_count, 0U);
-            EXPECT_GT(tunnel_runtime.stats.forwarded_packet_count, 0U);
-            EXPECT_LE(tunnel_runtime.stats.max_tunnel_payload_size, tunnel_payload_limit);
+            const auto stats = tunnel_bridge_stats(tunnel_runtime);
+            ASSERT_TRUE(stats.error.empty()) << stats.error;
+            EXPECT_GT(stats.received_packet_count, 0U);
+            EXPECT_GT(stats.forwarded_packet_count, 0U);
+            EXPECT_LE(stats.max_tunnel_payload_size, tunnel_payload_limit);
         }
     }
 } // namespace

--- a/tests/tmp/e2e_payload.bin
+++ b/tests/tmp/e2e_payload.bin
@@ -1,2 +1,0 @@
-FLUTE end-to-end payload
-1234567890abcdefghijklmnopqrstuvwxyz


### PR DESCRIPTION
Adds an end-to-end test for transmitter-side UDP tunnelling.

* `run_end_to_end_scenario` runs both direct and tunneled delivery variants. In the tunneled variant, the transmitter sends an outer UDP datagram to a local tunnel endpoint. Its payload is an inner IPv4+UDP packet containing the FLUTE/ALC payload. A test bridge receives that datagram, validates the inner IPv4 and UDP headers, strips them, and forwards the FLUTE/ALC payload to the normal receiver port.

* The PR also fixes tunneled asynchronous-send buffer ownership so the encapsulated packet remains alive until async_send_to completes. Previously, that buffer was released immediately after scheduling `async_send_to`. 