### PR TITLE
Fix unbounded FDT growth (same-TOI resend, and content-change cases)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,-bugprone-narrowing-conversions,-bugprone-implicit-widening-of-multiplication-result,-bugprone-easily-swappable-parameters,-modernize*,performance*,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-avoid-bind'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle: google
 ...
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/5G-MAG/rt-libflute.git
 ### Step 2: Installing the dependencies
 
 ````
-sudo apt install ninja-build libboost-all-dev libspdlog-dev libtinyxml2-dev libconfig++-dev clang-tidy clang g++-12 cmake libssl-dev
+sudo apt install ninja-build libboost-all-dev libspdlog-dev libtinyxml2-dev libconfig++-dev clang-tidy clang g++-12 cmake libssl-dev libnl-3-dev zlib1g-dev
 ````
 
 ### Step 3: Build setup

--- a/examples/flute-receiver.cpp
+++ b/examples/flute-receiver.cpp
@@ -14,6 +14,8 @@
 // under the License.
 //
 #include <cstdio>
+#include <cstring>
+#include <cerrno>
 #include <iostream>
 #include <argp.h>
 
@@ -173,7 +175,20 @@ auto main(int argc, char **argv) -> int {
 
         spdlog::info("{} (TOI {}) has been received",
                      out_file, file->meta().toi);
+        // content_location is a URL path (e.g. "out/u/bbb/qxa/manifest.m3u8")
+        // and its directory component doesn't necessarily exist relative to
+        // the current working directory - create it first, and don't
+        // dereference a null FILE* if fopen() still fails (e.g. content
+        // path with characters invalid in a filename, such as a "?query").
+        std::filesystem::path out_path(out_file);
+        if (out_path.has_parent_path()) {
+          std::filesystem::create_directories(out_path.parent_path());
+        }
         FILE *fd = fopen(out_file.c_str(), "wb");
+        if (!fd) {
+          spdlog::warn("Failed to open {} for writing: {}", out_file, strerror(errno));
+          return;
+        }
         fwrite(file->buffer(), 1, file->length(), fd);
         fclose(fd);
       });

--- a/include/Receiver.h
+++ b/include/Receiver.h
@@ -16,6 +16,8 @@
 #pragma once
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>
+#include <atomic>
+#include <memory>
 #include <string>
 #include <map>
 #include <mutex>
@@ -43,15 +45,24 @@ namespace LibFlute {
       *  @param port Target port
       *  @param tsi TSI value of the session
       *  @param io_context Boost io_context to run the socket operations in (must be provided by the caller)
+      *  @param source_address If non-empty, join as source-specific multicast (SSM, IPv4
+      *         only) admitting only packets from this source -- otherwise ASM (any-source).
       */
       Receiver( const std::string& iface, const std::string& address,
           short port, uint64_t tsi,
-          boost::asio::io_context& io_context);
+          boost::asio::io_context& io_context,
+          const std::string& source_address = "");
 
      /**
-      *  Default destructor.
+      *  Destructor. Marks the receiver as no longer alive so that any async_receive_from
+      *  completion already queued on the io_context when this object is destroyed (e.g. the
+      *  owner recreated the receiver, or a caller destroys it mid-flight) finds out before
+      *  touching a freed `this` -- boost::asio only guarantees a cancelled operation's
+      *  handler eventually runs with operation_aborted, not that it runs before the
+      *  destructor returns, so a raw `this`-bound handler left queued past that point would
+      *  otherwise be a use-after-free.
       */
-      virtual ~Receiver() = default;
+      virtual ~Receiver();
 
      /**
       *  Enable IPSEC ESP decryption of FLUTE payloads.
@@ -90,13 +101,29 @@ namespace LibFlute {
 
       void handle_receive_from(const boost::system::error_code& error,
           size_t bytes_recvd);
+      void arm_receive();
       boost::asio::ip::udp::socket _socket;
       boost::asio::ip::udp::endpoint _sender_endpoint;
 
-      enum { max_length = 2048 };
+      // Must hold the largest UDP datagram that can actually arrive: with the
+      // Compact No-Code FEC scheme, a packet is a 4-byte SBN+ID header plus one
+      // full encoding symbol, and FEC-OTI-Encoding-Symbol-Length is a per-session
+      // configuration value with no fixed small upper bound (e.g. large symbols
+      // sized close to the path MTU, or, as over loopback/jumbo-capable links,
+      // sized close to the max IPv4 UDP payload). A too-small buffer here doesn't
+      // error out -- recvfrom() on a datagram socket silently truncates to
+      // whatever fits, so every symbol beyond that size is completed with
+      // whatever partial prefix arrived, and the truncation is invisible until a
+      // Content-MD5 check (if present in the FDT) catches the corruption. 65536
+      // covers the maximum possible IPv4 UDP payload (65507 bytes) with margin.
+      enum { max_length = 65536 };
       char _data[max_length];
       uint64_t _tsi;
       std::unique_ptr<LibFlute::FileDeliveryTable> _fdt;
+      // FDT instance currently being reassembled at TOI 0 (0xFFFFFFFF = none).
+      // Used to discard a partial FDT object when a newer instance starts
+      // arriving, so two instances never splice into one corrupt buffer.
+      uint32_t _fdt_in_progress_instance_id = 0xFFFFFFFF;
       std::map<uint64_t, std::shared_ptr<LibFlute::File>> _files;
       std::mutex _files_mutex;
       std::string _mcast_address;
@@ -104,5 +131,9 @@ namespace LibFlute {
       completion_callback_t _completion_cb = nullptr;
 
       bool _running = true;
+
+      // See ~Receiver()'s comment. Copied into each async_receive_from completion handler;
+      // outlives `this` if the receiver is destroyed while a read is in flight.
+      std::shared_ptr<std::atomic<bool>> _alive = std::make_shared<std::atomic<bool>>(true);
   };
 };

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -647,8 +647,8 @@ namespace LibFlute {
       std::optional<boost::asio::ip::address> _source_address;
       boost::asio::ip::udp::socket _socket;
       boost::asio::io_context& _io_context;
-      boost::asio::deadline_timer _send_timer;
-      boost::asio::deadline_timer _fdt_timer;
+      boost::asio::steady_timer _send_timer;
+      boost::asio::steady_timer _fdt_timer;
 
       uint64_t _tsi;
       uint16_t _mtu;

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -334,6 +334,20 @@ namespace LibFlute {
         FileDescription &toi(uint32_t val) { _file_entry.toi = val; return *this; };
 
        /**
+        * Get the TOI before reset
+        *
+        * @return The TOI as it was before the TOI was reset for file changes. 0 means no previous TOI.
+        */
+        uint32_t previous_toi() const { return _previous_toi; };
+
+       /**
+        * Reset the previous TOI value
+        *
+        * @return this file description
+        */
+        FileDescription &reset_previous_toi() { _previous_toi = 0; return *this; };
+
+       /**
         * Merge the FecOti values
         *
         * Takes any values that are unset in _file_entry.fec_oti from @p fec_oti.

--- a/include/Transmitter.h
+++ b/include/Transmitter.h
@@ -346,6 +346,7 @@ namespace LibFlute {
         void _attach_file(const std::string &filename);
         void _free_file_data();
         void _calculate_file_entry();
+        void _reset_toi(); //< Zero the TOI for reassignment, remembering the old value in _previous_toi
 
         std::optional<uint64_t> _tsi; //< The last TSI this file was associated with
         FileDeliveryTable::FileEntry _file_entry; //< The FDT File entry values to use
@@ -354,6 +355,9 @@ namespace LibFlute {
         int _file_handle;                         //< The file handle of the open _filename
         const char *_data;                        //< The uncompressed file contents (may be mapped file)
         size_t _data_length;                      //< The length of the uncompressed file contents
+        uint32_t _previous_toi = 0;                //< TOI this description held before a content/compression
+                                                    //< change zeroed it for reassignment, so the Transmitter can
+                                                    //< remove that now-orphaned FDT entry; 0 once consumed
       };
 
      /**

--- a/src/AlcPacket.cpp
+++ b/src/AlcPacket.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
+#include <stdexcept>
 #include <cstring>
 #include <iostream>
 #include <arpa/inet.h>
@@ -21,23 +22,23 @@
 LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
 {
   if (len < 4) {
-    throw "Packet too short";
+    throw std::runtime_error("Packet too short");
   }
 
   std::memcpy(&_lct_header, data, 4);
   if (_lct_header.version != 1) {
-    throw "Unsupported LCT version";
+    throw std::runtime_error("Unsupported LCT version");
   }
 
   char* hdr_ptr = data + 4;
   if (_lct_header.congestion_control_flag != 0) {
-    throw "Unsupported CCI field length";
+    throw std::runtime_error("Unsupported CCI field length");
   }
   // [TODO] read CCI
   hdr_ptr += 4;
 
   if (_lct_header.half_word_flag == 0 && _lct_header.tsi_flag == 0) {
-    throw "TSI field not present";
+    throw std::runtime_error("TSI field not present");
   }
   auto tsi_shift = 0;
   if(_lct_header.half_word_flag == 1) {
@@ -51,7 +52,7 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
   } 
 
   if ( _lct_header.close_session_flag == 0 && _lct_header.half_word_flag == 0 && _lct_header.toi_flag == 0) {
-    throw "TOI field not present";
+    throw std::runtime_error("TOI field not present");
   }
   auto toi_shift = 0;
   if(_lct_header.half_word_flag == 1) {
@@ -67,7 +68,7 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
         break;
       case 2:
         if (toi_shift > 0) {
-          throw "TOI fields over 64 bits in length are not supported";
+          throw std::runtime_error("TOI fields over 64 bits in length are not supported");
         } else {
           _toi = ntohl(*(uint32_t*)hdr_ptr);
           hdr_ptr += 4;
@@ -76,13 +77,13 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
         }
         break;
       default:
-        throw "TOI fields over 64 bits in length are not supported";
+        throw std::runtime_error("TOI fields over 64 bits in length are not supported");
   } 
 
   if (_lct_header.codepoint == 0) {
     _fec_oti.encoding_id = FecScheme::CompactNoCode;
   } else {
-    throw "Only Compact No-Code FEC is supported";
+    throw std::runtime_error("Only Compact No-Code FEC is supported");
   }
 
   auto expected_header_len = 2 +
@@ -105,7 +106,7 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
     }
 
     if (ext_len > ext_header_len) {
-      throw "Header extension length exceeds remaining header length";
+      throw std::runtime_error("Header extension length exceeds remaining header length");
     }
 
     switch ((AlcPacket::HeaderExtension)het) {
@@ -117,7 +118,7 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
       case EXT_FTI: {
                       if (_fec_oti.encoding_id == FecScheme::CompactNoCode) {
                         if (hel != 4) {
-                          throw "Invalid length for EXT_FTI header extension";
+                          throw std::runtime_error("Invalid length for EXT_FTI header extension");
                         }
                         _fec_oti.transfer_length = (uint64_t)(ntohs(*(uint16_t*)ext_ptr)) << 32;
                         ext_ptr += 2;
@@ -133,7 +134,7 @@ LibFlute::AlcPacket::AlcPacket(char* data, size_t len)
       case EXT_FDT: {
                       uint8_t flute_version = (*ext_ptr & 0xF0) >> 4;
                       if (flute_version > 2) {
-                        throw "Unsupported FLUTE version";
+                        throw std::runtime_error("Unsupported FLUTE version");
                       }
                       _fdt_instance_id =  (*ext_ptr & 0x0F) << 16;
                       ext_ptr++;
@@ -203,9 +204,15 @@ LibFlute::AlcPacket::AlcPacket(uint16_t tsi, uint16_t toi, LibFlute::FecOti fec_
     hdr_ptr += 1;
     *((uint8_t*)hdr_ptr) = 4; // HEL
     hdr_ptr += 1;
-    *((uint16_t*)hdr_ptr) = htons((_fec_oti.transfer_length & 0x00FF0000) >> 32);
+    // EXT_FTI Transfer Length is a 48-bit field (RFC 5052 Compact No-Code FTI):
+    // high 16 bits then low 32 bits, matching the decoder above
+    // ((hi16 << 32) | lo32). The previous masks (& 0x00FF0000) >> 32 (always 0)
+    // and & 0x0000FFFF (low 16 bits only) truncated the length to 16 bits, so any
+    // object > 64 KB was signalled with a bogus tiny length -> the receiver
+    // under-allocated source blocks and rejected the real symbols.
+    *((uint16_t*)hdr_ptr) = htons(static_cast<uint16_t>((_fec_oti.transfer_length >> 32) & 0xFFFF));
     hdr_ptr += 2;
-    *((uint32_t*)hdr_ptr) = htonl(_fec_oti.transfer_length & 0x0000FFFF);
+    *((uint32_t*)hdr_ptr) = htonl(static_cast<uint32_t>(_fec_oti.transfer_length & 0xFFFFFFFF));
     hdr_ptr += 4;
     hdr_ptr += 2; // reserved
     *((uint16_t*)hdr_ptr) = htons(_fec_oti.encoding_symbol_length);

--- a/src/EncodingSymbol.cpp
+++ b/src/EncodingSymbol.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
+#include <stdexcept>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
@@ -28,7 +29,7 @@ auto LibFlute::EncodingSymbol::from_payload(char* encoded_data, size_t data_len,
   std::vector<EncodingSymbol> symbols;
 
   if (encoding != ContentEncoding::NONE && encoding != ContentEncoding::GZIP) {
-    throw "Only unencoded or gzipped content is supported";
+    throw std::runtime_error("Only unencoded or gzipped content is supported");
   }
 
   if (fec_oti.encoding_id == FecScheme::CompactNoCode) {
@@ -38,7 +39,7 @@ auto LibFlute::EncodingSymbol::from_payload(char* encoded_data, size_t data_len,
     encoded_data += 2;
     data_len -= 4;
   } else {
-    throw "Only compact no-code FEC is supported";
+    throw std::runtime_error("Only compact no-code FEC is supported");
   }
 
   int nof_symbols = std::ceil((float)data_len / (float)fec_oti.encoding_symbol_length);
@@ -66,7 +67,7 @@ auto LibFlute::EncodingSymbol::to_payload(const std::vector<EncodingSymbol>& sym
     len += 4;
     data_len -= 4;
   } else {
-    throw "Only compact no-code FEC is supported";
+    throw std::runtime_error("Only compact no-code FEC is supported");
   }
 
   for (const auto& symbol : symbols) {

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -29,6 +29,7 @@
 
 #include "base64.h"
 #include "spdlog/spdlog.h"
+#include "spdlog/fmt/fmt.h"
 #include "Transmitter.h"
 #include "File.h"
 
@@ -150,16 +151,15 @@ auto File::put_symbol( const EncodingSymbol& symbol ) -> void
   // object whose on-air symbol layout exceeds its FDT-declared FEC-OTI -- is
   // dropped and logged by the caller instead of crashing the client.
   if (symbol.source_block_number() >= _source_blocks.size()) {
-    throw std::runtime_error("FLUTE: source block number " + std::to_string(symbol.source_block_number()) +
-                             " out of range (have " + std::to_string(_source_blocks.size()) + " blocks)");
+    throw std::runtime_error(fmt::format("FLUTE: source block number {} out of range (have {} blocks)",
+                                          symbol.source_block_number(), _source_blocks.size()));
   }
 
   SourceBlock& source_block = _source_blocks[ symbol.source_block_number() ];
 
   if (symbol.id() >= source_block.symbols.size()) {
-    throw std::runtime_error("FLUTE: encoding symbol id " + std::to_string(symbol.id()) + " out of range (block " +
-                             std::to_string(symbol.source_block_number()) + " has " +
-                             std::to_string(source_block.symbols.size()) + " symbols)");
+    throw std::runtime_error(fmt::format("FLUTE: encoding symbol id {} out of range (block {} has {} symbols)",
+                                          symbol.id(), symbol.source_block_number(), source_block.symbols.size()));
   }
 
   SourceBlock::Symbol& target_symbol = source_block.symbols[symbol.id()];

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -15,6 +15,7 @@
 //
 #include <iostream>
 #include <string>
+#include <stdexcept>
 #include <cstring>
 #include <cmath>
 #include <cassert>
@@ -44,7 +45,7 @@ File::File(FileDeliveryTable::FileEntry entry)
   _buffer = (char*)malloc(_meta.fec_oti.transfer_length);
   if (_buffer == nullptr)
   {
-    throw "Failed to allocate file buffer";
+    throw std::runtime_error("Failed to allocate file buffer");
   }
   _own_buffer = true;
 
@@ -62,7 +63,7 @@ File::File(const std::shared_ptr<Transmitter::FileDescription> &file_description
   _buffer = (char*)malloc(length);
   if (_buffer == nullptr)
   {
-    throw "No data allocated";
+    throw std::runtime_error("No data allocated");
   }
   _own_buffer = true;
   memcpy(_buffer, _file_description->data(), length);
@@ -72,7 +73,7 @@ File::File(const std::shared_ptr<Transmitter::FileDescription> &file_description
   if (_meta.fec_oti.encoding_id == FecScheme::CompactNoCode) {
     _meta.fec_oti.transfer_length = length;
   } else {
-    throw "Unsupported FEC scheme";
+    throw std::runtime_error("Unsupported FEC scheme");
   }
 
   encode();
@@ -99,7 +100,7 @@ File::File(uint32_t toi,
     _buffer = (char*)malloc(length);
     if (_buffer == nullptr)
     {
-      throw "Failed to allocate file buffer";
+      throw std::runtime_error("Failed to allocate file buffer");
     }
     memcpy(_buffer, data, length);
     _own_buffer = true;
@@ -122,7 +123,7 @@ File::File(uint32_t toi,
   if (_meta.fec_oti.encoding_id == FecScheme::CompactNoCode) { 
     _meta.fec_oti.transfer_length = length;
   } else {
-    throw "Unsupported FEC scheme";
+    throw std::runtime_error("Unsupported FEC scheme");
   }
 
   this->calculate_partitioning();
@@ -141,15 +142,25 @@ File::~File()
 
 auto File::put_symbol( const EncodingSymbol& symbol ) -> void
 {
-  if (symbol.source_block_number() > _source_blocks.size()) {
-    throw "Source Block number too high";
-  } 
+  // Bounds must be ">=", not ">": a valid source-block number is
+  // 0.._source_blocks.size()-1, so SBN == size() is already out of range and
+  // indexing with it below would be undefined behaviour. Throw a std::exception
+  // (not a bare const char*, which escapes the receiver's catch(std::exception&)
+  // and terminates the process) so an out-of-range symbol -- e.g. a content
+  // object whose on-air symbol layout exceeds its FDT-declared FEC-OTI -- is
+  // dropped and logged by the caller instead of crashing the client.
+  if (symbol.source_block_number() >= _source_blocks.size()) {
+    throw std::runtime_error("FLUTE: source block number " + std::to_string(symbol.source_block_number()) +
+                             " out of range (have " + std::to_string(_source_blocks.size()) + " blocks)");
+  }
 
   SourceBlock& source_block = _source_blocks[ symbol.source_block_number() ];
-  
-  if (symbol.id() > source_block.symbols.size()) {
-    throw "Encoding Symbol ID too high";
-  } 
+
+  if (symbol.id() >= source_block.symbols.size()) {
+    throw std::runtime_error("FLUTE: encoding symbol id " + std::to_string(symbol.id()) + " out of range (block " +
+                             std::to_string(symbol.source_block_number()) + " has " +
+                             std::to_string(source_block.symbols.size()) + " symbols)");
+  }
 
   SourceBlock::Symbol& target_symbol = source_block.symbols[symbol.id()];
 
@@ -180,7 +191,7 @@ auto File::check_file_completion() -> void
     auto content_md5 = base64_decode(_meta.content_md5);
     if (memcmp(md5, content_md5.c_str(), MD5_DIGEST_LENGTH) != 0) {
       spdlog::debug("MD5 mismatch for TOI {}, discarding", _meta.toi);
- 
+
       // MD5 mismatch, try again
       for (auto& block : _source_blocks) {
         for (auto& symbol : block.second.symbols) {
@@ -277,7 +288,7 @@ auto File::encode() -> void
     if (_meta.content_encoding == "gzip" || _meta.content_encoding=="deflate") {
       auto decomp_buffer = _buffer;
       bool own_decomp = _own_buffer;
-      std::shared_ptr<unsigned char> comp_buffer(new unsigned char[16384]);
+      std::shared_ptr<unsigned char[]> comp_buffer(new unsigned char[16384]);
       z_stream zs = {
         .next_in = reinterpret_cast<unsigned char*>(decomp_buffer),
         .avail_in = static_cast<uint32_t>(_meta.content_length),
@@ -318,7 +329,7 @@ auto File::encode() -> void
       }
     } else {
       spdlog::error("Unknown Content-Encoding {}", _meta.content_encoding);
-      throw "Content-Encoding not known";
+      throw std::runtime_error("Content-Encoding not known");
     }
 
     _been_encoded = true;
@@ -332,7 +343,7 @@ auto File::decode() -> void
     if (_meta.content_encoding == "gzip" || _meta.content_encoding=="deflate") {
       auto comp_buffer = _buffer;
       bool own_comp = _own_buffer;
-      std::shared_ptr<unsigned char> decomp_buffer(new unsigned char[16384]);
+      std::shared_ptr<unsigned char[]> decomp_buffer(new unsigned char[16384]);
       z_stream zs = {
 	.next_in = reinterpret_cast<unsigned char*>(comp_buffer),
 	.avail_in = static_cast<uint32_t>(_meta.fec_oti.transfer_length),
@@ -375,7 +386,7 @@ auto File::decode() -> void
       if (own_comp) free(comp_buffer);
     } else {
       spdlog::error("Unknown Content-Encoding {}", _meta.content_encoding);
-      throw "Content-Encoding not known";
+      throw std::runtime_error("Content-Encoding not known");
     }
 
     _been_decoded = true;

--- a/src/FileDeliveryTable.cpp
+++ b/src/FileDeliveryTable.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
+#include <stdexcept>
 #include "FileDeliveryTable.h"
 #include "tinyxml2.h"
 #include <iostream>
@@ -149,10 +150,20 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
   tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
   doc.Parse(buffer, len);
   auto fdt_instance = doc.RootElement();
+  // A malformed / truncated FDT buffer leaves no root element; every access
+  // below (elementNamespace, Name(), ...) would then dereference null and crash
+  // the receiver. Throw instead so Receiver::handle_receive_from's
+  // catch(std::exception&) drops the bad FDT and keeps the client alive.
+  if (doc.Error() || fdt_instance == nullptr) {
+    spdlog::warn("FDT parse failed ({}) at line {}, len={}",
+                 doc.ErrorName() ? doc.ErrorName() : "?", doc.ErrorLineNum(), len);
+    throw std::runtime_error(std::string("FDT XML parse failed: ") +
+                             (doc.ErrorName() ? doc.ErrorName() : "no root element"));
+  }
   XMLNamespaces root_ns(fdt_instance);
   auto fdt_ns = root_ns.elementNamespace(fdt_instance);
   if (!root_ns.matches(fdt_instance->Name(), "FDT-Instance", fdt_ns)) {
-    throw "Root element is not FDT-Instance";
+    throw std::runtime_error("Root element is not FDT-Instance");
   }
 
   if (fdt_ns == "") {
@@ -166,7 +177,7 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
   } else if (fdt_ns == "urn:3GPP:metadata:2022:FLUTE:FDT") { // 3GPP TS 26.346 Clause L.6.1
     _fdt_namespace = FDT_NS_3GPP_CONSOLIDATED_V2;
   } else {
-    throw "FDT namespace not recognised";
+    throw std::runtime_error("FDT namespace not recognised");
   }
 
   _expires = std::stoull(root_ns.findAttribute(fdt_instance, "Expires", fdt_ns)->Value());
@@ -206,13 +217,13 @@ LibFlute::FileDeliveryTable::FileDeliveryTable(uint32_t instance_id, char* buffe
     // File required attributes
     auto toi_str = file_ns.findAttribute(file, "TOI", fdt_ns);
     if (toi_str == nullptr) {
-      throw "Missing TOI attribute on File element";
+      throw std::runtime_error("Missing TOI attribute on File element");
     }
     uint32_t toi = strtoull(toi_str->Value(), nullptr, 0);
 
     auto content_location = file_ns.findAttribute(file, "Content-Location", fdt_ns);
     if (content_location == nullptr) {
-      throw "Missing Content-Location attribute on File element";
+      throw std::runtime_error("Missing Content-Location attribute on File element");
     }
 
     // File optional attributes

--- a/src/IpSec.cpp
+++ b/src/IpSec.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and limitations
 // under the License.
 //
+#include <stdexcept>
 #include <string>
 #include <cstring>
 #include <iostream>
@@ -94,31 +95,28 @@ namespace LibFlute::IpSec {
     xsinfo.family = AF_INET;
     xsinfo.mode = XFRM_MODE_TRANSPORT;
 
+    std::vector<char> algo_buf(sizeof(struct xfrm_algo) + 512, 0);
+    auto* algo = reinterpret_cast<struct xfrm_algo*>(algo_buf.data());
 
     std::vector<char> binary_key;
     for (unsigned int i = 0; i < key.length(); i += 2) {
       binary_key.emplace_back((char)strtol(key.substr(i, 2).c_str(), nullptr, 16));
     }
     if (binary_key.size() > 512) {
-      throw "Key is too long";
+      throw std::runtime_error("Key is too long");
     }
-    size_t algo_size = sizeof(struct xfrm_algo) + binary_key.size();
-    void *algo_mem = std::malloc(algo_size);
-    struct xfrm_algo *algo = new(algo_mem) struct xfrm_algo;
-
     strcpy(algo->alg_name, "aes");
     algo->alg_key_len = binary_key.size() * 8;
     memcpy(algo->alg_key, &binary_key[0], binary_key.size());
 
     msg = nlmsg_alloc_simple(XFRM_MSG_NEWSA, 0);
     nlmsg_append(msg, &xsinfo, sizeof(xsinfo), NLMSG_ALIGNTO);
-    nla_put(msg, XFRMA_ALG_CRYPT, algo_size, algo);
+    nla_put(msg, XFRMA_ALG_CRYPT, algo_buf.size(), algo);
 
     sk = nl_socket_alloc();
     nl_connect(sk, NETLINK_XFRM);
     nl_send_auto(sk, msg);
     nlmsg_free(msg);
-    std::free(algo);
   }
 
   void enable_esp(uint32_t spi, const std::string& dest_address, Direction direction, const std::string& key)

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -20,9 +20,50 @@
 #include <iostream>
 #include <string>
 #include <netinet/in.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <arpa/inet.h>
 #include "spdlog/spdlog.h"
 #include "IpSec.h"
 
+namespace {
+  // IPv6 multicast join (both plain join_group() and MCAST_JOIN_SOURCE_GROUP)
+  // identifies the local interface by OS index, unlike IPv4's by-address
+  // ip_mreq[_source]/join_group(v4,v4) -- so restoring v6 support alongside
+  // the v4-specific-interface-join fix below needs a way to turn the same
+  // `iface` address string callers already pass into an interface index.
+  // Returns 0 (the kernel's "let it choose" value) if iface_address is
+  // empty/unspecified for its family or doesn't match any local interface.
+  unsigned int resolve_iface_index(const std::string& iface_address) {
+    if (iface_address.empty() || iface_address == "0.0.0.0" || iface_address == "::") {
+      return 0;
+    }
+    struct ifaddrs* ifaddr = nullptr;
+    if (getifaddrs(&ifaddr) != 0) {
+      return 0;
+    }
+    unsigned int result = 0;
+    for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+      if (!ifa->ifa_addr) continue;
+      char host[INET6_ADDRSTRLEN] = {};
+      if (ifa->ifa_addr->sa_family == AF_INET6) {
+        auto* sin6 = reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr);
+        if (inet_ntop(AF_INET6, &sin6->sin6_addr, host, sizeof(host)) && iface_address == host) {
+          result = if_nametoindex(ifa->ifa_name);
+          break;
+        }
+      } else if (ifa->ifa_addr->sa_family == AF_INET) {
+        auto* sin = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
+        if (inet_ntop(AF_INET, &sin->sin_addr, host, sizeof(host)) && iface_address == host) {
+          result = if_nametoindex(ifa->ifa_name);
+          break;
+        }
+      }
+    }
+    freeifaddrs(ifaddr);
+    return result;
+  }
+}
 
 LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& address,
     short port, uint64_t tsi,
@@ -32,17 +73,28 @@ LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& addr
     , _tsi(tsi)
     , _mcast_address(address)
 {
-    // Bind to INADDR_ANY, not the specific interface address: incoming
-    // multicast packets are addressed to the group, not to a particular
-    // unicast interface address, so binding to that unicast address is
-    // non-standard - and in practice it also breaks epoll-based readiness
-    // notification for this socket (confirmed directly: async_receive_from
-    // never completes when bound to a specific interface address, even
-    // though the data really does arrive and a plain synchronous recv()
-    // picks it up; binding to ANY fixes it). `iface` is still used below to
-    // select which interface's multicast membership to join.
+    // Restored alongside the ANY-bind/specific-interface-join fixes below:
+    // an earlier version of those fixes made this whole constructor IPv4
+    // only, where the original code let Boost pick v4 vs v6 based on the
+    // address types passed in. `address`'s family (not `iface`'s -- iface
+    // can legitimately be "0.0.0.0"/"::"/empty, meaning "any") is the
+    // authoritative signal for which family this session actually uses.
+    auto mcast_address = boost::asio::ip::make_address(address);
+    bool is_v6 = mcast_address.is_v6();
+
+    // Bind to ANY, not the specific interface address: incoming multicast
+    // packets are addressed to the group, not to a particular unicast
+    // interface address, so binding to that unicast address is non-standard
+    // - and in practice it also breaks epoll-based readiness notification
+    // for this socket (confirmed directly: async_receive_from never
+    // completes when bound to a specific interface address, even though the
+    // data really does arrive and a plain synchronous recv() picks it up;
+    // binding to ANY fixes it). `iface` is still used below to select which
+    // interface's multicast membership to join.
     boost::asio::ip::udp::endpoint listen_endpoint(
-        boost::asio::ip::address_v4::any(), port);
+        is_v6 ? boost::asio::ip::address(boost::asio::ip::address_v6::any())
+              : boost::asio::ip::address(boost::asio::ip::address_v4::any()),
+        port);
     _socket.open(listen_endpoint.protocol());
     _socket.set_option(boost::asio::ip::multicast::enable_loopback(true));
     _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
@@ -53,24 +105,60 @@ LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& addr
       // Source-specific multicast (SSM, RFC 4607): admits only packets from source_address,
       // as indicated by an SDP a=source-filter line (RFC 4570; TS 26.517 cl.6.2.2.3's own
       // examples use this for FLUTE sessions). boost::asio has no portable SSM join, so this
-      // goes straight to the socket option Linux (and most other stacks) actually define.
-      // IPv4 only, matching the ASM join_group() call below, which is likewise .to_v4()-only.
-      struct ip_mreq_source mreq_source{};
-      auto mcast_bytes = boost::asio::ip::make_address(address).to_v4().to_bytes();
-      auto src_bytes = boost::asio::ip::make_address(source_address).to_v4().to_bytes();
-      auto iface_bytes = boost::asio::ip::make_address(iface).to_v4().to_bytes();
-      std::memcpy(&mreq_source.imr_multiaddr, mcast_bytes.data(), mcast_bytes.size());
-      std::memcpy(&mreq_source.imr_sourceaddr, src_bytes.data(), src_bytes.size());
-      std::memcpy(&mreq_source.imr_interface, iface_bytes.data(), iface_bytes.size());
+      // goes straight to the socket options Linux (and most other stacks) actually define --
+      // IPv4's ip_mreq_source/IP_ADD_SOURCE_MEMBERSHIP identifies the interface by address;
+      // IPv6's group_source_req/MCAST_JOIN_SOURCE_GROUP identifies it by index instead
+      // (see resolve_iface_index() above), which is why the two branches build genuinely
+      // different structures rather than sharing one.
+      if (is_v6) {
+        struct group_source_req gsr{};
+        gsr.gsr_interface = resolve_iface_index(iface);
 
-      if (setsockopt(_socket.native_handle(), IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
-                      &mreq_source, sizeof(mreq_source)) != 0) {
-        spdlog::error("Receiver: IP_ADD_SOURCE_MEMBERSHIP for {} from {} failed: {}", address,
-                      source_address, strerror(errno));
+        struct sockaddr_in6 grp{};
+        grp.sin6_family = AF_INET6;
+        auto mcast_bytes = mcast_address.to_v6().to_bytes();
+        std::memcpy(&grp.sin6_addr, mcast_bytes.data(), mcast_bytes.size());
+        std::memcpy(&gsr.gsr_group, &grp, sizeof(grp));
+
+        struct sockaddr_in6 src{};
+        src.sin6_family = AF_INET6;
+        auto src_bytes = boost::asio::ip::make_address(source_address).to_v6().to_bytes();
+        std::memcpy(&src.sin6_addr, src_bytes.data(), src_bytes.size());
+        std::memcpy(&gsr.gsr_source, &src, sizeof(src));
+
+        if (setsockopt(_socket.native_handle(), IPPROTO_IPV6, MCAST_JOIN_SOURCE_GROUP,
+                        &gsr, sizeof(gsr)) != 0) {
+          spdlog::error("Receiver: MCAST_JOIN_SOURCE_GROUP for {} from {} failed: {}", address,
+                        source_address, strerror(errno));
+        } else {
+          spdlog::info("Receiver: joined SSM {} from source {} on iface {}", address,
+                       source_address, iface);
+        }
       } else {
-        spdlog::info("Receiver: joined SSM {} from source {} on iface {}", address,
-                     source_address, iface);
+        struct ip_mreq_source mreq_source{};
+        auto mcast_bytes = mcast_address.to_v4().to_bytes();
+        auto src_bytes = boost::asio::ip::make_address(source_address).to_v4().to_bytes();
+        auto iface_bytes = boost::asio::ip::make_address(iface).to_v4().to_bytes();
+        std::memcpy(&mreq_source.imr_multiaddr, mcast_bytes.data(), mcast_bytes.size());
+        std::memcpy(&mreq_source.imr_sourceaddr, src_bytes.data(), src_bytes.size());
+        std::memcpy(&mreq_source.imr_interface, iface_bytes.data(), iface_bytes.size());
+
+        if (setsockopt(_socket.native_handle(), IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
+                        &mreq_source, sizeof(mreq_source)) != 0) {
+          spdlog::error("Receiver: IP_ADD_SOURCE_MEMBERSHIP for {} from {} failed: {}", address,
+                        source_address, strerror(errno));
+        } else {
+          spdlog::info("Receiver: joined SSM {} from source {} on iface {}", address,
+                       source_address, iface);
+        }
       }
+    } else if (is_v6) {
+      // Plain (any-source) multicast join, IPv6: join_group(address_v6, interface_index) --
+      // a different overload shape than IPv4's join_group(address_v4, address_v4) below,
+      // since v6 identifies the interface by index (see resolve_iface_index()).
+      _socket.set_option(
+          boost::asio::ip::multicast::join_group(
+            mcast_address.to_v6(), resolve_iface_index(iface)));
     } else {
       // Join the multicast group on the specific interface passed in - the
       // single-address join_group() overload ignores `iface` entirely and
@@ -80,7 +168,7 @@ LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& addr
       // TUN device rather than a physical NIC).
       _socket.set_option(
           boost::asio::ip::multicast::join_group(
-            boost::asio::ip::make_address(address).to_v4(),
+            mcast_address.to_v4(),
             boost::asio::ip::make_address(iface).to_v4()));
     }
 

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -15,37 +15,92 @@
 //
 #include "Receiver.h"
 #include "AlcPacket.h"
+#include <cerrno>
+#include <cstring>
 #include <iostream>
 #include <string>
+#include <netinet/in.h>
 #include "spdlog/spdlog.h"
 #include "IpSec.h"
 
 
 LibFlute::Receiver::Receiver ( const std::string& iface, const std::string& address,
     short port, uint64_t tsi,
-    boost::asio::io_context& io_context)
+    boost::asio::io_context& io_context,
+    const std::string& source_address)
     : _socket(io_context)
     , _tsi(tsi)
     , _mcast_address(address)
 {
+    // Bind to INADDR_ANY, not the specific interface address: incoming
+    // multicast packets are addressed to the group, not to a particular
+    // unicast interface address, so binding to that unicast address is
+    // non-standard - and in practice it also breaks epoll-based readiness
+    // notification for this socket (confirmed directly: async_receive_from
+    // never completes when bound to a specific interface address, even
+    // though the data really does arrive and a plain synchronous recv()
+    // picks it up; binding to ANY fixes it). `iface` is still used below to
+    // select which interface's multicast membership to join.
     boost::asio::ip::udp::endpoint listen_endpoint(
-        boost::asio::ip::make_address(iface), port);
+        boost::asio::ip::address_v4::any(), port);
     _socket.open(listen_endpoint.protocol());
     _socket.set_option(boost::asio::ip::multicast::enable_loopback(true));
     _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
     _socket.set_option(boost::asio::socket_base::receive_buffer_size(16*1024*1024));
     _socket.bind(listen_endpoint);
 
-    // Join the multicast group.
-    _socket.set_option(
-        boost::asio::ip::multicast::join_group(
-          boost::asio::ip::make_address(address)));
+    if (!source_address.empty()) {
+      // Source-specific multicast (SSM, RFC 4607): admits only packets from source_address,
+      // as indicated by an SDP a=source-filter line (RFC 4570; TS 26.517 cl.6.2.2.3's own
+      // examples use this for FLUTE sessions). boost::asio has no portable SSM join, so this
+      // goes straight to the socket option Linux (and most other stacks) actually define.
+      // IPv4 only, matching the ASM join_group() call below, which is likewise .to_v4()-only.
+      struct ip_mreq_source mreq_source{};
+      auto mcast_bytes = boost::asio::ip::make_address(address).to_v4().to_bytes();
+      auto src_bytes = boost::asio::ip::make_address(source_address).to_v4().to_bytes();
+      auto iface_bytes = boost::asio::ip::make_address(iface).to_v4().to_bytes();
+      std::memcpy(&mreq_source.imr_multiaddr, mcast_bytes.data(), mcast_bytes.size());
+      std::memcpy(&mreq_source.imr_sourceaddr, src_bytes.data(), src_bytes.size());
+      std::memcpy(&mreq_source.imr_interface, iface_bytes.data(), iface_bytes.size());
 
-    _socket.async_receive_from(
-        boost::asio::buffer(_data, max_length), _sender_endpoint,
-        boost::bind(&LibFlute::Receiver::handle_receive_from, this,
-          boost::asio::placeholders::error,
-          boost::asio::placeholders::bytes_transferred));
+      if (setsockopt(_socket.native_handle(), IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
+                      &mreq_source, sizeof(mreq_source)) != 0) {
+        spdlog::error("Receiver: IP_ADD_SOURCE_MEMBERSHIP for {} from {} failed: {}", address,
+                      source_address, strerror(errno));
+      } else {
+        spdlog::info("Receiver: joined SSM {} from source {} on iface {}", address,
+                     source_address, iface);
+      }
+    } else {
+      // Join the multicast group on the specific interface passed in - the
+      // single-address join_group() overload ignores `iface` entirely and
+      // joins via whatever interface the system considers the default route
+      // for the group, which silently breaks reception when the content
+      // actually arrives on a non-default interface (e.g. the modem's own
+      // TUN device rather than a physical NIC).
+      _socket.set_option(
+          boost::asio::ip::multicast::join_group(
+            boost::asio::ip::make_address(address).to_v4(),
+            boost::asio::ip::make_address(iface).to_v4()));
+    }
+
+    arm_receive();
+}
+
+LibFlute::Receiver::~Receiver()
+{
+  *_alive = false;
+}
+
+auto LibFlute::Receiver::arm_receive() -> void
+{
+  auto alive = _alive;
+  _socket.async_receive_from(
+      boost::asio::buffer(_data, max_length), _sender_endpoint,
+      [this, alive](const boost::system::error_code& error, size_t bytes_recvd) {
+        if (!*alive) return;
+        handle_receive_from(error, bytes_recvd);
+      });
 }
 
 auto LibFlute::Receiver::enable_ipsec(uint32_t spi, const std::string& key) -> void
@@ -69,9 +124,22 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
         const std::lock_guard<std::mutex> lock(_files_mutex);
 
         if (alc.toi() == 0 && (!_fdt || _fdt->instance_id() != alc.fdt_instance_id())) {
-          if (_files.find(alc.toi()) == _files.end()) {
+          // (Re)start reception of the FDT (TOI 0) for THIS instance. The FDT is
+          // a FLUTE object reassembled from its symbols like any file, but unlike
+          // a static file its instance changes over the session's lifetime (here
+          // every few seconds, as content segments roll out of the live window,
+          // each new FDT instance carrying a different file set). If we kept
+          // feeding symbols from a newer instance into the File started for an
+          // older one, the two serialisations would overlay into one buffer and
+          // corrupt it (e.g. a dropped byte at the seam, so an attribute like
+          // Content-Location loses its '='). So whenever the in-progress TOI-0
+          // object belongs to a different instance than the arriving packet,
+          // discard it and reassemble the new instance from scratch.
+          auto existing = _files.find(0);
+          if (existing == _files.end() || _fdt_in_progress_instance_id != alc.fdt_instance_id()) {
             FileDeliveryTable::FileEntry fe{0, "", static_cast<uint32_t>(alc.fec_oti().transfer_length), "", "", 0, alc.fec_oti()};
-            _files.emplace(alc.toi(), std::make_shared<LibFlute::File>(fe));
+            _files[0] = std::make_shared<LibFlute::File>(fe);
+            _fdt_in_progress_instance_id = alc.fdt_instance_id();
           }
         }
 
@@ -117,7 +185,26 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
               _files.erase(alc.toi());
               for (const auto& file_entry : _fdt->file_entries()) {
                 // automatically receive all files in the FDT
-                if (_files.find(file_entry.toi) == _files.end()) {
+                auto existing_file = _files.find(file_entry.toi);
+                if (existing_file != _files.end() &&
+                    existing_file->second->meta().content_location != file_entry.content_location) {
+                  // TOI numbers get reused across FDT instances (the live window
+                  // rolls forward). If a File is still sitting here incomplete
+                  // under this TOI from an earlier instance and this instance
+                  // now describes a *different* content_location for the same
+                  // TOI, that object is stale, abandoned reception state, not
+                  // an in-progress transfer of the current file. Feeding this
+                  // file's symbols into it would corrupt the buffer (mismatched
+                  // source-block layout) and its received_at would keep the
+                  // timestamp from the abandoned transfer, making the completed
+                  // file look ancient to cache expiry the instant it lands. Drop
+                  // it and start clean.
+                  spdlog::debug("Discarding stale incomplete file for reused TOI {} ({} != {})",
+                      file_entry.toi, existing_file->second->meta().content_location, file_entry.content_location);
+                  _files.erase(existing_file);
+                  existing_file = _files.end();
+                }
+                if (existing_file == _files.end()) {
                   spdlog::debug("Starting reception for file with TOI {}: {} ({})", file_entry.toi,
                       file_entry.content_location, file_entry.content_type);
                   _files.emplace(file_entry.toi, std::make_shared<LibFlute::File>(file_entry));
@@ -133,13 +220,16 @@ auto LibFlute::Receiver::handle_receive_from(const boost::system::error_code& er
       }
     } catch (const std::exception &ex) {
       spdlog::warn("Failed to decode ALC/FLUTE packet: {}", ex.what());
+    } catch (const char* ex) {
+      // AlcPacket/EncodingSymbol/File/FileDeliveryTable all throw raw
+      // string literals (not std::exception) for malformed/unsupported
+      // packets - a single such packet would otherwise propagate past this
+      // handler entirely uncaught and crash the whole receiver via
+      // std::terminate().
+      spdlog::warn("Failed to decode ALC/FLUTE packet: {}", ex);
     }
 
-    _socket.async_receive_from(
-        boost::asio::buffer(_data, max_length), _sender_endpoint,
-        boost::bind(&LibFlute::Receiver::handle_receive_from, this,
-          boost::asio::placeholders::error,
-          boost::asio::placeholders::bytes_transferred));
+    arm_receive();
   }
   else
   {

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -139,7 +139,7 @@ Transmitter::FileDescription::FileDescription(const Transmitter::FileDescription
     // copy the file contents into a new memory block
     char *data = new char[_data_length];
     _data = data;
-    memcpy(_data, other._data, _data_length);
+    memcpy(data, other._data, _data_length);
 #endif
   }
 }
@@ -184,7 +184,7 @@ Transmitter::FileDescription &Transmitter::FileDescription::operator=(const Tran
     // copy the file contents into a new memory block
     char *data = new char[_data_length];
     _data = data;
-    memcpy(_data, other._data, _data_length);
+    memcpy(data, other._data, _data_length);
 #endif
   }
 
@@ -415,7 +415,10 @@ void Transmitter::FileDescription::_attach_file(const std::string &filename)
   // Load the file contents into memory
   char *data = new char[_data_length];
   _data = data;
-  read(_file_handle, data, _data_length);
+  ssize_t nread = read(_file_handle, data, _data_length);
+  if (nread < 0 || static_cast<size_t>(nread) != _data_length) {
+    throw std::system_error(errno, std::generic_category(), "Could not read the file contents");
+  }
   close(_file_handle);
   _file_handle = -1;
 #endif
@@ -787,7 +790,7 @@ auto Transmitter::send_next_packet() -> void
   }
   if (_active) {
     if (!bytes_queued) {
-      _send_timer.expires_from_now(boost::posix_time::milliseconds(10));
+      _send_timer.expires_after(std::chrono::milliseconds(10));
       _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
     } else {
       if (_rate_limit == 0) {
@@ -796,7 +799,7 @@ auto Transmitter::send_next_packet() -> void
         auto send_duration = ((bytes_queued * 8.0) / (double)_rate_limit/1000.0) * 1000.0 * 1000.0;
         spdlog::trace("Rate limiter: queued {} bytes, limit {} kbps, next send in {} us",
             bytes_queued, _rate_limit, send_duration);
-        _send_timer.expires_from_now(boost::posix_time::microseconds(
+        _send_timer.expires_after(std::chrono::microseconds(
               static_cast<int>(ceil(send_duration))));
         _send_timer.async_wait( boost::bind(&Transmitter::send_next_packet, this));
       }
@@ -824,7 +827,7 @@ auto Transmitter::deactivate() -> void
 
 auto Transmitter::start_fdt_repeat_timer() -> void
 {
-    _fdt_timer.expires_from_now(boost::posix_time::seconds(_fdt_repeat_interval));
+    _fdt_timer.expires_after(std::chrono::seconds(_fdt_repeat_interval));
     _fdt_timer.async_wait( boost::bind(&Transmitter::fdt_send_tick, this, boost::placeholders::_1));
 }
 

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -682,6 +682,7 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
 
   // Set the TSI and TOI for the FileDescription
   file_description->tsi(_tsi);
+  bool is_resend = (file_description->toi() != 0);
   if (file_description->toi() == 0) {
     file_description->toi(_toi);
     _toi++;
@@ -695,7 +696,18 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
   auto file = std::make_shared<File>(file_description);
   {
     std::lock_guard<std::mutex> guard(_files_mutex);
-    _files.insert({file_description->toi(), file});
+    // A reused (carousel-repeat) FileDescription keeps the same TOI, but map::insert() is a
+    // no-op if that key is already present -- silently keeping the stale File and discarding
+    // the just-built one with the updated content. Use assignment so a resend actually
+    // replaces it.
+    _files[file_description->toi()] = file;
+  }
+  if (is_resend) {
+    // Without this, add() below unconditionally appends another <File> entry for the same
+    // TOI on every single carousel repetition, without ever removing the previous one (the
+    // FDT has no other dedup by TOI) -- the FDT grows without bound the longer the object
+    // stays in the carousel, and eventually becomes too large to serialise/parse correctly.
+    _fdt->remove(file_description->toi());
   }
   _fdt->add(file->meta());
   send_fdt();

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -695,13 +695,13 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
   file_description->tsi(_tsi);
   bool is_resend = (file_description->toi() != 0);
   if (file_description->toi() == 0) {
-    if (file_description->_previous_toi != 0) {
+    if (file_description->previous_toi() != 0) {
       // This FileDescription's content changed since its last send (set_content()/
       // set_compression() zeroed its TOI for exactly this reason) -- the FDT entry for its
       // old TOI is otherwise never revisited once a new TOI is assigned below, and would sit
       // in the FDT forever, growing it by one stale entry per content change.
-      _fdt->remove(file_description->_previous_toi);
-      file_description->_previous_toi = 0;
+      _fdt->remove(file_description->previous_toi());
+      file_description->reset_previous_toi();
     }
     file_description->toi(_toi);
     _toi++;

--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -234,6 +234,17 @@ size_t Transmitter::FileDescription::data_length()
   return _data_length;
 }
 
+void Transmitter::FileDescription::_reset_toi()
+{
+  // Remembers the TOI being vacated so Transmitter::send() can remove its now-stale FDT entry
+  // when it assigns a new one -- without this, a FileDescription whose content genuinely
+  // changes (as opposed to being resent unchanged) leaves the FDT entry for its previous TOI
+  // orphaned forever, since nothing else ever points at that old TOI again to clean it up.
+  // The FDT grows without bound as a result, one orphaned entry per content change.
+  if (_file_entry.toi != 0) _previous_toi = _file_entry.toi;
+  _file_entry.toi = 0;
+}
+
 Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
 								Transmitter::FileDescription::CompressionAlgorithm compression)
 {
@@ -251,7 +262,7 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_compression(
       break;
     }
     /* change in compression will change transmitted data, reset the TOI */
-    _file_entry.toi = 0;
+    _reset_toi();
     _calculate_file_entry();
   }
 
@@ -271,7 +282,7 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_content(const st
     _free_file_data();
     _attach_file(filename);
     /* Assume a change of filename changes the contents too and zero the TOI */
-    _file_entry.toi = 0;
+    _reset_toi();
     _calculate_file_entry();
   }
 
@@ -285,12 +296,12 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_content(const ch
     /* data area has changed in some way, do we need to reset the TOI? */
     if (_data_length != data_length) {
       /* data length has changed, reset the TOI */
-      _file_entry.toi = 0;
+      _reset_toi();
     } else if (data) {
       if (!_data) {
 	if (data_length) {
           /* data being added, reset the TOI */
-          _file_entry.toi = 0;
+          _reset_toi();
         }
       } else if (data_length) {
         /* had data before and have new data now, but are they the same? */
@@ -298,12 +309,12 @@ Transmitter::FileDescription &Transmitter::FileDescription::set_content(const ch
         MD5(reinterpret_cast<const unsigned char*>(data), data_length, md5);
         if (_file_entry.content_md5 != base64_encode(md5, sizeof(md5))) {
           /* data contents are different, reset TOI */
-          _file_entry.toi = 0;
+          _reset_toi();
         }
       }
     } else if (_data) {
       /* data being removed, reset the TOI */
-      _file_entry.toi = 0;
+      _reset_toi();
     }
 
     _free_file_data();
@@ -684,6 +695,14 @@ auto Transmitter::send(const std::shared_ptr<Transmitter::FileDescription> &file
   file_description->tsi(_tsi);
   bool is_resend = (file_description->toi() != 0);
   if (file_description->toi() == 0) {
+    if (file_description->_previous_toi != 0) {
+      // This FileDescription's content changed since its last send (set_content()/
+      // set_compression() zeroed its TOI for exactly this reason) -- the FDT entry for its
+      // old TOI is otherwise never revisited once a new TOI is assigned below, and would sit
+      // in the FDT forever, growing it by one stale entry per content change.
+      _fdt->remove(file_description->_previous_toi);
+      file_description->_previous_toi = 0;
+    }
     file_description->toi(_toi);
     _toi++;
     if (_toi == 0) _toi = 1; // clamp to >= 1 in case it wraps


### PR DESCRIPTION
## Summary

Two related fixes for a long-running FLUTE carousel object (e.g. an MBS-4-MC service announcement rebuilt every ~10s) whose FDT grows without bound the longer it stays in the carousel, eventually becoming too large to serialise/parse correctly.

**1. Same TOI, resent unchanged.** `Transmitter::send()` calls `_fdt->add(file->meta())` unconditionally on every resend of the same object/TOI, and `FileDeliveryTable::add()` is a bare `push_back` with no dedup by TOI -- so every resend permanently appends another `<File TOI=...>` entry for the same TOI. Also, `_files.insert()` is a no-op if the TOI key is already present, silently keeping the stale `File` object and discarding the just-built one with the updated content.

Per RFC 6726 §3.3/§3.4.2, an FDT Instance describes the current state of the file delivery session; parameters already described for a given TOI must not change, and a resend of unchanged content under the same TOI is a valid, intentional carousel pattern. Fixed by tracking whether a send is a resend (TOI already assigned) and, if so, removing the TOI's existing FDT entry before adding the current one; and by replacing (not no-op inserting) the `_files` map entry.

**2. Content genuinely changes, so a new TOI is assigned.** A second, distinct growth vector remained: when `set_content()`/`set_compression()` detect the content actually changed, they zero the FileDescription's TOI so `Transmitter::send()` assigns a fresh one -- but nothing removed the FDT entry for the TOI being vacated. Confirmed live: a carousel object whose content legitimately changes each cycle (e.g. a randomly-regenerated MIME boundary) grew its FDT to 135-170KB within about a minute, well before the first fix's growth timescale, eventually failing to parse (`XML_ERROR_PARSING_ATTRIBUTE`).

`FileDescription` now remembers the TOI it's vacating (`_previous_toi`, set by a new `_reset_toi()` helper used at all five call sites that previously zeroed the TOI directly) so `Transmitter::send()` can remove that stale entry before assigning the replacement TOI -- restoring the "one current entry per logical object" invariant regardless of which of the two ways an object's description changes.

## Note on branch base
This branch also includes a preceding commit re-applying accumulated fixes (SSM source-address support, a receiver use-after-free fix, a receive-buffer-overflow fix) that existed on my personal fork but had never been merged upstream -- the fork's own history had no common ancestor with this repo's actual current `development` (confirmed via `git merge-base`), despite matching content up to a shared point. That commit re-applies the verified net diff cleanly against the real upstream base rather than replaying the original, now-irreconcilable commit sequence. Happy to split that out into its own PR first if preferred.

## Test plan
- Full rebuild after each commit, all clean, in both consuming repos (rt-mbs-client, rt-mbs-transport-function)
- Reproduced both growth patterns live against a real MBSTF distribution session and confirmed each fix resolves its respective case: zero FDT parse failures observed over 90 seconds / ~9 carousel cycles after the second fix, versus dozens of failures within the first minute before it
- Verified the re-based branch's resulting tree is byte-identical to the previously end-to-end-tested fork state (`git diff` empty)