### PR TITLE
Bug-fix: Fix incorrect function call during FLUTE object compression

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -309,7 +309,7 @@ auto File::encode() -> void
           _own_buffer = true;
           zs.avail_out = 16384;
           zs.next_out = comp_buffer.get();
-          zstate = inflate(&zs, Z_FINISH);
+          zstate = deflate(&zs, Z_FINISH);
         }
         if (zstate==Z_STREAM_END) {
           if (last_out != zs.total_out) {


### PR DESCRIPTION
After triggering object compression, while testing 5G-MAG/rt-mbs-transport-function#66, it was noted that the FLUTE library often crashed trying to compress the file object. This was due to a copy/paste error from the decompression routine which mistakenly used `inflate()` instead of `deflate()` during compression.

This PR corrects the compression routine to use `deflate()` correctly.