### PR TITLE
Bind to the configured source address even when tunnelling

### DIFF
--- a/src/Transmitter.cpp
+++ b/src/Transmitter.cpp
@@ -524,7 +524,12 @@ Transmitter::Transmitter ( const std::string& destination_address, short port,
   _socket.set_option(boost::asio::ip::multicast::enable_loopback(true));
   _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));
 
-  if (_source_address && !_tunnel_endpoint) {
+  /* A tunnelled session still sends an untunnelled copy to the real multicast destination, and
+     that copy has to originate from the configured source address too, or a receiver filtering
+     on the announced source (an SDP a=source-filter, say) never matches it. Binding was skipped
+     whenever a tunnel was configured, on the assumption the socket only ever reached the tunnel
+     endpoint. */
+  if (_source_address) {
     _socket.bind(boost::asio::ip::udp::endpoint(_source_address.value(),0));
   }
 
@@ -607,7 +612,12 @@ auto Transmitter::endpoint(boost::asio::ip::udp::endpoint &&destination) -> Tran
 auto Transmitter::source_address(const std::optional<boost::asio::ip::address> &source_address) -> Transmitter&
 {
   _source_address = source_address;
-  if (_source_address && !_tunnel_endpoint) {
+  /* A tunnelled session still sends an untunnelled copy to the real multicast destination, and
+     that copy has to originate from the configured source address too, or a receiver filtering
+     on the announced source (an SDP a=source-filter, say) never matches it. Binding was skipped
+     whenever a tunnel was configured, on the assumption the socket only ever reached the tunnel
+     endpoint. */
+  if (_source_address) {
     _socket.bind(boost::asio::ip::udp::endpoint(_source_address.value(),0));
   }
   return *this;
@@ -616,7 +626,12 @@ auto Transmitter::source_address(const std::optional<boost::asio::ip::address> &
 auto Transmitter::source_address(std::optional<boost::asio::ip::address> &&source_address) -> Transmitter&
 {
   _source_address = std::move(source_address);
-  if (_source_address && !_tunnel_endpoint) {
+  /* A tunnelled session still sends an untunnelled copy to the real multicast destination, and
+     that copy has to originate from the configured source address too, or a receiver filtering
+     on the announced source (an SDP a=source-filter, say) never matches it. Binding was skipped
+     whenever a tunnel was configured, on the assumption the socket only ever reached the tunnel
+     endpoint. */
+  if (_source_address) {
     _socket.bind(boost::asio::ip::udp::endpoint(_source_address.value(),0));
   }
   return *this;


### PR DESCRIPTION

Closes #82.
**Change type:** crash fix, in the sense of traffic silently not arriving.

Binding the send socket to the configured source address was skipped whenever a tunnel endpoint was set,
on the assumption the socket then only reaches the tunnel. It does not: a tunnelled session also sends an
untunnelled copy to the real multicast destination, and that copy left from whichever address the host
chose, so a receiver filtering on the announced source never matched it.

The guard now tests only whether a source address is configured, at all three sites.

Extracted from the Raptor branch, which had carried it unrelated to FEC.

**Verification.** T1: 39 cases passing. No test covers the bind address; the existing tunnel end-to-end
test passes unchanged, which is the regression check available.
