### PR TITLE
Release the IPsec netlink socket instead of leaking it

### DIFF
--- a/src/IpSec.cpp
+++ b/src/IpSec.cpp
@@ -67,6 +67,8 @@ namespace LibFlute::IpSec {
     nl_connect(sk, NETLINK_XFRM);
     nl_send_auto(sk, msg);
     nlmsg_free(msg);
+    /* Without this the netlink socket and its fd leak on every call. */
+    nl_socket_free(sk);
   }
   void configure_state(uint32_t spi, const std::string& dest_address, Direction direction, const std::string& key)
   {
@@ -117,6 +119,8 @@ namespace LibFlute::IpSec {
     nl_connect(sk, NETLINK_XFRM);
     nl_send_auto(sk, msg);
     nlmsg_free(msg);
+    /* Without this the netlink socket and its fd leak on every call. */
+    nl_socket_free(sk);
   }
 
   void enable_esp(uint32_t spi, const std::string& dest_address, Direction direction, const std::string& key)


### PR DESCRIPTION

Closes #83.
**Change type:** crash fix.

`configure_policy()` and `configure_state()` each allocate a netlink socket and never release it, so
every call leaks the socket and its file descriptor. `nl_socket_free()` on both paths.

Extracted from the Raptor branch, which had carried it unrelated to FEC.

**Verification.** T1: 39 cases passing. No test covers it: exercising it needs CAP_NET_ADMIN and a real
netlink socket, which the suite does not have.

**Not in this change.** The three larger defects in the same file, described in #83: discarded netlink
return values, ESP without integrity protection, and an IPv6 destination accepted although the code can
only express IPv4.
