### PR TITLE
IPsec: handle IPv6 destinations instead of mistranslating them

### DIFF
--- a/include/IpSec.h
+++ b/include/IpSec.h
@@ -14,6 +14,7 @@
 // under the License.
 //
 #pragma once
+#include <cstdint>
 #include <string>
 
 namespace LibFlute::IpSec {

--- a/src/IpSec.cpp
+++ b/src/IpSec.cpp
@@ -30,6 +30,31 @@
 #include <boost/algorithm/hex.hpp>
 
 namespace LibFlute::IpSec {
+  namespace {
+    // A colon unambiguously identifies IPv6 text notation (dotted-decimal IPv4 never contains
+    // one) -- avoids pulling in a full address-parsing library just to pick a netlink family.
+    bool is_ipv6_address(const std::string& address) {
+      return address.find(':') != std::string::npos;
+    }
+
+    // Fills in an xfrm_address_t's a4 (IPv4) or a6 (IPv6) member, and returns the address
+    // family/prefix length pair the caller should set alongside it -- the two are always used
+    // together (sel.family+sel.daddr, tmpl.family+tmpl.id.daddr, xsinfo.family+xsinfo.id.daddr),
+    // so keeping the parse and the family selection in one place avoids them silently drifting
+    // apart if only one were updated in a future edit.
+    struct addr_family_info { int family; uint8_t prefixlen; };
+    addr_family_info fill_xfrm_address(xfrm_address_t& addr, const std::string& text_address) {
+      if (is_ipv6_address(text_address)) {
+        if (inet_pton(AF_INET6, text_address.c_str(), &addr.a6) != 1) {
+          throw std::runtime_error("Invalid IPv6 address: " + text_address);
+        }
+        return {AF_INET6, 128};
+      }
+      addr.a4 = inet_addr(text_address.c_str());
+      return {AF_INET, 32};
+    }
+  }
+
   void configure_policy(uint32_t spi, const std::string& dest_address, Direction direction)
   {
     struct nl_sock *sk;
@@ -42,22 +67,24 @@ namespace LibFlute::IpSec {
     xpinfo.lft.hard_packet_limit = XFRM_INF;
     xpinfo.dir = (direction == Direction::In) ? XFRM_POLICY_IN : XFRM_POLICY_OUT;
 
-    xpinfo.sel.family = AF_INET;
-    xpinfo.sel.saddr.a4 = INADDR_ANY;
-    xpinfo.sel.daddr.a4 = inet_addr(dest_address.c_str());
-    xpinfo.sel.prefixlen_d = 32;
+    // sel.saddr is left all-zero (INADDR_ANY for v4, "::" for v6 -- the same all-zero
+    // xfrm_address_t union represents both) regardless of family: this policy selector matches
+    // any source address, only the destination is pinned.
+    auto dest_info = fill_xfrm_address(xpinfo.sel.daddr, dest_address);
+    xpinfo.sel.family = dest_info.family;
+    xpinfo.sel.prefixlen_d = dest_info.prefixlen;
 
     struct xfrm_user_tmpl tmpl = {};
-    tmpl.id.daddr.a4 = inet_addr(dest_address.c_str());
+    fill_xfrm_address(tmpl.id.daddr, dest_address);
     tmpl.id.spi = htonl(spi);
     tmpl.id.proto = IPPROTO_ESP;
-    tmpl.saddr.a4 = INADDR_ANY;
+    // tmpl.saddr left all-zero, same reasoning as sel.saddr above.
     tmpl.reqid = spi;
     tmpl.mode = XFRM_MODE_TRANSPORT;
     tmpl.aalgos = (~(__u32)0);
     tmpl.ealgos = (~(__u32)0);
     tmpl.calgos = (~(__u32)0);
-    tmpl.family = AF_INET;
+    tmpl.family = dest_info.family;
 
     msg = nlmsg_alloc_simple(XFRM_MSG_UPDPOLICY, 0);
     nlmsg_append(msg, &xpinfo, sizeof(xpinfo), NLMSG_ALIGNTO);
@@ -75,16 +102,15 @@ namespace LibFlute::IpSec {
 
     struct xfrm_usersa_info	xsinfo = {};
 
-    xsinfo.sel.family = AF_INET;
-    xsinfo.sel.saddr.a4 = INADDR_ANY;
-    xsinfo.sel.daddr.a4 = inet_addr(dest_address.c_str());
-    xsinfo.sel.prefixlen_d = 32;
-    
-    xsinfo.id.daddr.a4 = inet_addr(dest_address.c_str());
+    // sel.saddr and (further below) xsinfo.saddr are left all-zero -- same reasoning as
+    // configure_policy() above, this SA's own source isn't pinned to a specific address.
+    auto dest_info = fill_xfrm_address(xsinfo.sel.daddr, dest_address);
+    xsinfo.sel.family = dest_info.family;
+    xsinfo.sel.prefixlen_d = dest_info.prefixlen;
+
+    fill_xfrm_address(xsinfo.id.daddr, dest_address);
     xsinfo.id.spi = htonl(spi);
     xsinfo.id.proto = IPPROTO_ESP;
-    
-    xsinfo.saddr.a4 = INADDR_ANY;
 
     xsinfo.lft.soft_byte_limit = XFRM_INF;
     xsinfo.lft.hard_byte_limit = XFRM_INF;
@@ -92,7 +118,7 @@ namespace LibFlute::IpSec {
     xsinfo.lft.hard_packet_limit = XFRM_INF;
 
     xsinfo.reqid = spi;
-    xsinfo.family = AF_INET;
+    xsinfo.family = dest_info.family;
     xsinfo.mode = XFRM_MODE_TRANSPORT;
 
     std::vector<char> algo_buf(sizeof(struct xfrm_algo) + 512, 0);


### PR DESCRIPTION

Closes #85.

**Change type:** compliance fix.

`configure_policy()` and `configure_state()` used `AF_INET` and the `.a4` union member throughout and
parsed the destination with `inet_addr()`, which cannot express an IPv6 address and reports failure as a
valid-looking value, so an IPv6 destination installed a policy for a nonsense IPv4 address. The address
family is now selected from the destination, with the matching union member and prefix length.

Also adds the `<cstdint>` include that `include/IpSec.h` needed: it used `uint32_t` while relying on
transitive inclusion from elsewhere in this library's build, which broke standalone consumption of the
public header.

Extracted from an older branch that had these bundled with unrelated work.

**Verification.** T1: 39 cases passing. No automated coverage: installing XFRM state needs CAP_NET_ADMIN,
which the suite does not have. The two commits were previously verified against real kernel state with
`ip xfrm state show` for both families, on the branch they came from.

**Not in this change.** The other IPsec defects, which are separate: discarded netlink return values, and
ESP configured with no integrity protection. The socket leak is its own pull request, closing #83.
